### PR TITLE
Fix cp: can't preserve ownership during init in Docker

### DIFF
--- a/cli/libexec/init/devcontainer
+++ b/cli/libexec/init/devcontainer
@@ -84,7 +84,7 @@ devcontainer() {
 
 	mkdir -p "$devcontainer_dir"
 	# Use rsync-style copy to include dotfiles (glob * skips them)
-	cp -a "$SCT_TEMPLATEDIR/devcontainer/." "$devcontainer_dir/"
+	cp -R "$SCT_TEMPLATEDIR/devcontainer/." "$devcontainer_dir/"
 
 	local rel_settings_file="../$settings_file"
 


### PR DESCRIPTION
## Summary

- Replace `cp -a` with `cp -R` when copying devcontainer templates in `sandcat init`
- The `-a` flag tries to preserve file ownership (`chown`), which fails when running as root inside the Docker container and writing to a host-mounted volume (e.g. macOS with Rancher Desktop)
- `-R` copies recursively (still including dotfiles via the `/.` source pattern) without attempting to change ownership

Fixes #44

## Test plan

- [ ] Run `sandcat init` via the Docker alias on macOS (Rancher Desktop / Docker Desktop)
- [ ] Verify `.devcontainer/` files are created without permission errors
- [ ] Verify dotfiles (if any) in the template directory are still copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)