### PR TITLE
Fix init prompt ordering: show prompt before options

### DIFF
--- a/cli/lib/select.bash
+++ b/cli/lib/select.bash
@@ -32,7 +32,7 @@ select_option() {
 	local default="${options[0]}"
 	local i
 
-	echo "$prompt [$default]" >&2
+	printf '%s\n' "$prompt [$default]" >&2
 	for i in "${!options[@]}"; do
 		echo "  $((i+1))) ${options[$i]}" >&2
 	done
@@ -82,7 +82,7 @@ select_multiple() {
 		fi
 	done
 
-	echo "$prompt" >&2
+	printf '%s\n' "$prompt" >&2
 	local i
 	for i in "${!options[@]}"; do
 		local marker=""

--- a/cli/lib/select.bash
+++ b/cli/lib/select.bash
@@ -32,13 +32,14 @@ select_option() {
 	local default="${options[0]}"
 	local i
 
+	echo "$prompt [$default]" >&2
 	for i in "${!options[@]}"; do
 		echo "  $((i+1))) ${options[$i]}" >&2
 	done
 
 	local reply
 	while true; do
-		read -rp "$prompt [$default] " reply >&2
+		read -rp "> " reply >&2
 		if [[ -z $reply ]]; then
 			printf '%s\n' "$default"
 			return
@@ -81,6 +82,7 @@ select_multiple() {
 		fi
 	done
 
+	echo "$prompt" >&2
 	local i
 	for i in "${!options[@]}"; do
 		local marker=""
@@ -96,7 +98,7 @@ select_multiple() {
 
 	local reply
 	while true; do
-		read -rp "$prompt " reply >&2
+		read -rp "> " reply >&2
 		if [[ -z $reply ]]; then
 			# Return defaults on empty input
 			echo "${defaults[*]+${defaults[*]}}"


### PR DESCRIPTION
## Summary
- Reorders `select_option()` and `select_multiple()` in `cli/lib/select.bash` to display the prompt text before the numbered options list, matching conventional CLI UX
- Uses a `> ` input indicator instead of repeating the prompt text on the input line

Before:
```
  1) claude
Select agent: [claude]
```

After:
```
Select agent: [claude]
  1) claude
> 
```

Fixes #46

## Test plan
- [x] `bats cli/test/select/select.bats` — all 20 tests pass
- [x] `bats cli/test/init/init.bats` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)