### PR TITLE
Fix tput errors on unknown terminals (e.g. Ghostty)

### DIFF
--- a/cli/lib/logging.bash
+++ b/cli/lib/logging.bash
@@ -4,7 +4,7 @@
 # Example usage:
 # `echo 'Terrible error' | error`
 
-if ! command -v tput &>/dev/null
+if ! tput sgr0 &>/dev/null
 then
 	tput() { :; }
 fi

--- a/cli/run-tests.bash
+++ b/cli/run-tests.bash
@@ -73,7 +73,7 @@ then
 	echo "Total $(jq -r '.percent_covered' <"$coverage_dir/merged/kcov-merged/coverage.json")%"
 fi
 
-if ! command -v tput &>/dev/null; then
+if ! tput sgr0 &>/dev/null; then
 	tput() { :; }
 fi
 


### PR DESCRIPTION
## Summary
- `cli/lib/logging.bash` (and `cli/run-tests.bash`) only checked whether `tput` was installed, not whether it could handle the current `$TERM`. On terminals whose terminfo entry is missing from the system database — notably `xterm-ghostty` on stock macOS — every `info`/`warning`/`error` call emitted `tput: unknown terminal "xterm-ghostty"` to stderr, producing output like `10:35:49 tput: unknown terminal "xterm-ghostty"` during `sandcat init`.
- Probe with `tput sgr0 &>/dev/null` instead, so the no-op stub is installed whenever tput cannot handle the current terminal.

## Test plan
- [x] `TERM=xterm-ghostty bash -c 'source cli/lib/logging.bash && echo test | info'` — no stderr noise, log line is plain.
- [x] `TERM=xterm-256color bash -c 'source cli/lib/logging.bash && echo test | info'` — color escapes still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)