### PR TITLE
Add sandcat attach command to attach to already running container

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ another terminal), use `attach` to open an additional shell in it without starti
 container:
 
 ```bash
-sandcat attach
+sandcat attach           # opens bash --login
+sandcat attach <cmd>     # runs <cmd> directly, e.g. sandcat attach zsh
 ```
 
 Unlike `sandcat run`, this connects to an existing container rather than starting a fresh one.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ sandcat run --build
 claude-yolo
 ```
 
+**Attaching to a running container:**
+
+If the sandbox is already running (e.g. started by VS Code's devcontainer integration or
+another terminal), use `attach` to open an additional shell in it without starting a new
+container:
+
+```bash
+sandcat attach
+```
+
+Unlike `sandcat run`, this connects to an existing container rather than starting a fresh one.
+It uses `find_compose_file` to locate the correct project, so it works reliably even when
+multiple sandboxes are running in parallel.
+
 ### Customizing the generated files
 
 **`compose-all.yml`** — `network_mode: "service:wg-client"` routes all traffic
@@ -830,6 +844,12 @@ Start the container from the command line:
 
 ```sh
 sandcat run
+```
+
+Attach a shell to an already-running container:
+
+```sh
+sandcat attach
 ```
 
 Tear down all containers and volumes (resets persisted home directory):

--- a/cli/libexec/attach/_
+++ b/cli/libexec/attach/_
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# this will catch unmatched commands, otherwise `sandcat attach foobar` would try
+# to execute `foobar` as a command in this module
+
+exec attach "$@"

--- a/cli/libexec/attach/attach
+++ b/cli/libexec/attach/attach
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=../../lib/require.bash
+source "$SCT_LIBDIR/require.bash"
+# shellcheck source=../../lib/path.bash
+source "$SCT_LIBDIR/path.bash"
+
+attach() {
+	require docker
+
+	local compose_file
+	compose_file="$(find_compose_file)"
+
+	exec docker compose -f "$compose_file" exec -u vscode agent bash --login
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+	attach "$@"
+fi

--- a/cli/libexec/attach/attach
+++ b/cli/libexec/attach/attach
@@ -12,7 +12,12 @@ attach() {
 	local compose_file
 	compose_file="$(find_compose_file)"
 
-	exec docker compose -f "$compose_file" exec -u vscode agent bash --login
+	if (($# == 0))
+	then
+		exec docker compose -f "$compose_file" exec -u vscode agent bash --login
+	fi
+
+	exec docker compose -f "$compose_file" exec -u vscode agent "$@"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]


### PR DESCRIPTION
Opens a login shell in the already-running agent container of the current project, using `find_compose_file` to target the right project even when multiple sandboxes run in parallel.

Basically it's a "smart" alias to:

```
docker compose -f <compose_file> exec -u vscode agent bash --login
```