### PR TITLE
Add extra_hosts settings field for resolving internal hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ no files exist, the addon disables itself.
 **Merge rules:**
 - `env` — merged; higher-precedence values overwrite lower ones.
 - `secrets` — merged; higher-precedence entries overwrite lower ones.
+- `extra_hosts` — merged; higher-precedence entries overwrite lower ones.
 - `network` — concatenated; highest-precedence rules come first. Since rules are
   evaluated top-to-bottom with first-match-wins, this means local rules take
   priority over project rules, which take priority over user rules.
@@ -798,6 +799,58 @@ would otherwise be forwarded by Docker's embedded resolver to the host's
 upstream DNS, bypassing mitmproxy — wg-client is launched with a `dns:` sink
 (RFC 5737 `192.0.2.1`). Sibling names still resolve locally; anything else
 under the search domain fails fast without leaving the host.
+
+### Resolving internal hostnames — `extra_hosts`
+
+DNS inside the sandbox goes through mitmproxy to public resolvers (or the
+`dns_servers` you configured), so names that only live in your host's
+`/etc/hosts` or on an unroutable internal network won't resolve. Use
+`extra_hosts` in `settings.json` to map hostnames to IPs; the addon writes
+them to a sidecar file which `wg-client` splices into its `/etc/hosts`
+inside a `# sandcat extra_hosts` sentinel block. The agent inherits that
+file via `network_mode: service:wg-client`, so `getent hosts <name>`,
+`curl`, `mvn`, Java's `InetAddress` etc. resolve the name via NSS before
+any DNS query.
+
+```json
+{
+  "extra_hosts": {
+    "maven-proxy.corp": "192.168.1.100",
+    "jira.internal": "10.0.0.50"
+  },
+  "network": [
+    {"action": "allow", "host": "maven-proxy.corp"},
+    {"action": "allow", "host": "jira.internal"}
+  ]
+}
+```
+
+**A matching network allow rule is still required.** Mitmproxy enforces
+network policy on the HTTP `Host` / TLS `SNI` regardless of how the name
+was resolved. Without an allow rule, requests to the internal host are
+blocked with 403.
+
+**Merge rules.** `extra_hosts` is a dict merged across the three settings
+layers (user / project / local); higher precedence overwrites per-key.
+
+**Validation.** Invalid entries are logged as warnings and skipped; the
+container still starts. Requirements:
+- **Hostname** — RFC-1123 label (letters, digits, hyphens, max 253 chars).
+  A trailing dot (`nexus.corp.`) is stripped before validation.
+- **IP** — IPv4 or IPv6 accepted by Python's `ipaddress` module.
+
+**IPv6 caveat.** Sandcat's kill-switch drops outbound IPv6 traffic
+(`ip6tables -A OUTPUT -o eth0 -j DROP`) so mapping a name to an IPv6
+address will resolve via NSS but the connection itself will time out.
+The addon logs a warning for IPv6 entries but still writes them, in case
+you're using them for tools that only need name-to-address lookup (e.g.
+some healthchecks) rather than actual connectivity.
+
+**Applying changes.** Run `sandcat restart-proxy` to re-read settings —
+the sentinel block in `/etc/hosts` is replaced atomically on each start.
+Processes already running inside the agent may cache DNS results (Java
+`sun.net.InetAddressCachePolicy`, curl connection pool, etc.) and won't
+pick up the change until they reconnect or the agent is restarted.
 
 ## Secret substitution
 

--- a/cli/templates/devcontainer/sandcat/scripts/mitmproxy_addon_common.py
+++ b/cli/templates/devcontainer/sandcat/scripts/mitmproxy_addon_common.py
@@ -54,6 +54,12 @@ from fnmatch import fnmatch
 from mitmproxy import ctx, dns, http
 
 _VALID_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# RFC-1123 label / RFC-2181 length. Trailing dot is stripped before validation
+# so `nexus.corp.` normalises to `nexus.corp`.
+_VALID_HOSTNAME = re.compile(
+    r"^(?=.{1,253}$)[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$"
+)
 
 # Settings layers, lowest to highest precedence.
 SETTINGS_PATHS = [
@@ -67,6 +73,11 @@ CURSOR_CLI_CONFIG_PATH = "/home/mitmproxy/.mitmproxy/cursor-cli-config.json"
 # One IPv4/IPv6 address per line; empty or missing file means "use defaults".
 # (glibc/musl resolvers reject hostnames in `nameserver` directives.)
 SANDCAT_DNS_CONF_PATH = "/home/mitmproxy/.mitmproxy/dns.conf"
+# Sidecar file consumed by wg-client-init.sh. `IP<TAB>hostname` per line.
+# ALWAYS written by the addon (empty file when nothing configured) so
+# wg-client-init treats file-existence as authoritative and can clean out
+# stale entries from previous runs.
+EXTRA_HOSTS_PATH = "/home/mitmproxy/.mitmproxy/extra_hosts"
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +124,9 @@ class SandcatAddon:
             # signals "addon has loaded" for the mitmproxy healthcheck.
             self._write_dns_conf()
             self._write_cursor_cli_config({})
+            # Truncate extra_hosts too, so a stale file from a previous run
+            # doesn't leak entries into /etc/hosts when the addon is disabled.
+            self._write_extra_hosts({})
             logger.info("No settings files found — addon disabled")
             return
 
@@ -134,6 +148,7 @@ class SandcatAddon:
         self._write_placeholders_env()
         self._write_cursor_cli_config(merged)
         self._write_dns_conf()
+        self._write_extra_hosts(merged["extra_hosts"])
 
         ctx.log.info(
             f"Loaded {len(self.env)} env var(s), {len(self.secrets)} secret(s), "
@@ -304,6 +319,7 @@ class SandcatAddon:
 
         - env: dict merge, higher precedence overwrites.
         - secrets: dict merge, higher precedence overwrites.
+        - extra_hosts: dict merge, higher precedence overwrites.
         - network: concatenated, highest precedence first (top-to-bottom matching).
         - cursor.cli: deep merge, higher precedence overwrites nested keys.
         - op_service_account_token: highest precedence non-empty value wins.
@@ -314,6 +330,7 @@ class SandcatAddon:
         """
         env: dict[str, str] = {}
         secrets: dict[str, dict] = {}
+        extra_hosts: dict[str, str] = {}
         network: list[dict] = []
         cursor_cli: dict = {}
         op_token: str | None = None
@@ -323,6 +340,7 @@ class SandcatAddon:
         for layer in layers:
             env.update(layer.get("env", {}))
             secrets.update(layer.get("secrets", {}))
+            extra_hosts.update(layer.get("extra_hosts", {}))
             layer_cursor = layer.get("cursor", {})
             layer_cli = layer_cursor.get("cli", {})
             if layer_cli:
@@ -343,6 +361,7 @@ class SandcatAddon:
         return {
             "env": env,
             "secrets": secrets,
+            "extra_hosts": extra_hosts,
             "network": network,
             "cursor": {"cli": cursor_cli},
             "op_service_account_token": op_token,
@@ -556,6 +575,65 @@ class SandcatAddon:
         if self.dns_servers:
             ctx.log.info(
                 f"Wrote {len(self.dns_servers)} custom DNS server(s) to {SANDCAT_DNS_CONF_PATH}"
+            )
+
+    def _write_extra_hosts(self, extra_hosts: dict[str, str]):
+        """Write extra_hosts entries as an /etc/hosts-format file.
+
+        Consumed by wg-client-init.sh, which appends the file inside a
+        sentinel block in /etc/hosts. The agent inherits that /etc/hosts
+        via network_mode: service:wg-client, so `getent hosts <name>`
+        resolves the name via NSS before any DNS query.
+
+        Invalid entries are logged and skipped; the container still starts.
+        ALWAYS writes the file (empty when nothing configured) so
+        wg-client-init can treat file-existence as authoritative and clean
+        stale entries from previous runs.
+
+        IPv6 entries are validated but the container's kill-switch drops
+        outbound IPv6 traffic (ip6tables -A OUTPUT -o eth0 -j DROP), so
+        connections to IPv6-mapped hosts will fail — a warning is logged
+        but the entry is still written for NSS resolution consistency.
+        """
+        lines: list[str] = []
+        for raw_name, address in extra_hosts.items():
+            name = raw_name.rstrip(".") if isinstance(raw_name, str) else raw_name
+            if not isinstance(name, str) or not name or not _VALID_HOSTNAME.match(name):
+                ctx.log.warn(f"extra_hosts: invalid hostname {raw_name!r}, skipping")
+                continue
+            if not isinstance(address, str):
+                ctx.log.warn(
+                    f"extra_hosts[{name!r}]: value must be a string, skipping"
+                )
+                continue
+            try:
+                parsed = ipaddress.ip_address(address)
+            except ValueError:
+                ctx.log.warn(
+                    f"extra_hosts[{name!r}]: {address!r} is not a valid IP, skipping"
+                )
+                continue
+            if isinstance(parsed, ipaddress.IPv6Address):
+                ctx.log.warn(
+                    f"extra_hosts[{name!r}]: IPv6 address {address!r} accepted for "
+                    "NSS lookup but sandcat's kill-switch drops outbound IPv6 traffic"
+                )
+            lines.append(f"{address}\t{name}")
+
+        body = "\n".join(lines)
+        if lines:
+            body += "\n"
+        try:
+            self._atomic_write_text(EXTRA_HOSTS_PATH, body)
+        except OSError as e:
+            ctx.log.warn(
+                f"Could not write {EXTRA_HOSTS_PATH}: {e!r}; "
+                "wg-client will continue with its previous /etc/hosts entries"
+            )
+            return
+        if lines:
+            ctx.log.info(
+                f"Wrote {len(lines)} extra_hosts entry(ies) to {EXTRA_HOSTS_PATH}"
             )
 
     def _find_matching_rule(self, method: str | None, host: str) -> dict | None:

--- a/cli/templates/devcontainer/sandcat/scripts/wg-client-init.sh
+++ b/cli/templates/devcontainer/sandcat/scripts/wg-client-init.sh
@@ -276,6 +276,37 @@ main() {
     mkdir -p "$(dirname "$SHARED_RESOLV_CONF")"
     write_resolv_conf "$SHARED_RESOLV_CONF" "${search_domains[@]}"
 
+    # ── Apply extra_hosts from settings ────────────────────────────────────────
+    # The mitmproxy addon writes user-configured extra_hosts entries to the
+    # shared volume (empty file when nothing configured — see
+    # _write_extra_hosts). Splice them into /etc/hosts inside a sentinel block;
+    # the agent inherits our /etc/hosts via network_mode: service:wg-client, so
+    # `getent hosts <name>` resolves there via NSS before any DNS query.
+    #
+    # Always strip the sentinel block first (even when the sidecar file is
+    # absent) so stale entries from a previous run cannot leak into a fresh
+    # startup where extra_hosts has been emptied. Then re-append only when the
+    # sidecar file is non-empty.
+    #
+    # /etc/hosts is bind-mounted by Docker, so `sed -i` fails at rename(2)
+    # with EBUSY ("Device or resource busy"). Read the file into a variable,
+    # filter the sentinel block out, then truncate + rewrite in place so we
+    # never leave the file's inode.
+    EXTRA_HOSTS_FILE="/mitmproxy-config/extra_hosts"
+    hosts_content=$(awk '
+        /^# sandcat extra_hosts BEGIN/ { skip = 1; next }
+        /^# sandcat extra_hosts END/   { skip = 0; next }
+        !skip
+    ' /etc/hosts)
+    printf '%s\n' "$hosts_content" > /etc/hosts
+    if [[ -s "$EXTRA_HOSTS_FILE" ]]; then
+        {
+            echo "# sandcat extra_hosts BEGIN"
+            cat "$EXTRA_HOSTS_FILE"
+            echo "# sandcat extra_hosts END"
+        } >> /etc/hosts
+    fi
+
     # Signal readiness to containers waiting on the healthcheck.
     touch /tmp/wg-ready
 

--- a/cli/test/mitmproxy/test_mitmproxy_addon.py
+++ b/cli/test/mitmproxy/test_mitmproxy_addon.py
@@ -138,6 +138,18 @@ def _patch_cursor_cli_config_path(tmp_path):
         yield
 
 
+@pytest.fixture(autouse=True)
+def _patch_extra_hosts_path(tmp_path_factory):
+    """load() writes extra_hosts sidecar; keep it off the real mitmproxy home.
+
+    Tests that care about the file's contents re-patch this locally with a
+    known path (see TestExtraHosts).
+    """
+    path = tmp_path_factory.mktemp("extra_hosts_default") / "extra_hosts"
+    with patch(f"{_COMMON}.EXTRA_HOSTS_PATH", str(path)):
+        yield
+
+
 def _make_flow(method="GET", host="example.com", url=None, headers=None, content=None):
     flow = MagicMock()
     flow.request = _Request(
@@ -1855,6 +1867,7 @@ class TestSettingsMerging:
         assert merged == {
             "env": {},
             "secrets": {},
+            "extra_hosts": {},
             "network": [],
             "cursor": {"cli": {}},
             "op_service_account_token": None,
@@ -1924,6 +1937,99 @@ class TestSettingsMerging:
         merged = BaseAddon._merge_settings(layers)
         assert merged["dns_servers"] is None
 
+    def test_extra_hosts_higher_precedence_wins(self):
+        layers = [
+            {"extra_hosts": {"a.corp": "10.0.0.1", "b.corp": "10.0.0.2"}},
+            {"extra_hosts": {"b.corp": "10.0.0.99"}},
+        ]
+        merged = BaseAddon._merge_settings(layers)
+        assert merged["extra_hosts"] == {"a.corp": "10.0.0.1", "b.corp": "10.0.0.99"}
+
+
+
+@pytest.mark.parametrize("addon_cls", ADDONS)
+class TestExtraHosts:
+    def _load_with_settings(self, addon_cls, tmp_path, settings):
+        p = tmp_path / "settings.json"
+        p.write_text(json.dumps(settings))
+        hosts_path = tmp_path / "extra_hosts"
+        addon = addon_cls()
+        with patch(f"{_COMMON}.SETTINGS_PATHS", [str(p)]), \
+             patch(f"{_COMMON}.SANDCAT_ENV_PATH", str(tmp_path / "sandcat.env")), \
+             patch(f"{_COMMON}.SANDCAT_DNS_CONF_PATH", str(tmp_path / "dns.conf")), \
+             patch(f"{_COMMON}.EXTRA_HOSTS_PATH", str(hosts_path)):
+            addon.load(MagicMock())
+        return hosts_path.read_text() if hosts_path.exists() else None
+
+    def test_writes_hosts_file_in_etc_hosts_format(self, addon_cls, tmp_path):
+        content = self._load_with_settings(addon_cls, tmp_path, {
+            "extra_hosts": {"maven.corp": "10.0.0.5", "jira.corp": "10.0.0.6"},
+        })
+        assert "10.0.0.5\tmaven.corp" in content
+        assert "10.0.0.6\tjira.corp" in content
+
+    def test_writes_empty_file_when_no_entries(self, addon_cls, tmp_path):
+        # Even when `extra_hosts` is absent from settings, the file MUST exist
+        # (empty), so wg-client-init can treat file-existence as authoritative
+        # and clean stale entries from previous runs.
+        content = self._load_with_settings(addon_cls, tmp_path, {
+            "network": [{"action": "allow", "host": "*"}],
+        })
+        assert content == ""
+
+    def test_ipv6_address_accepted(self, addon_cls, tmp_path):
+        # IPv6 accepted for NSS lookup even though the container's kill-switch
+        # drops outbound IPv6 (documented behaviour, matches _write_extra_hosts
+        # docstring). Test guards against regression that silently drops the entry.
+        content = self._load_with_settings(addon_cls, tmp_path, {
+            "extra_hosts": {"v6.corp": "2001:db8::1"},
+        })
+        assert "2001:db8::1\tv6.corp" in content
+
+    def test_invalid_ip_skipped(self, addon_cls, tmp_path):
+        content = self._load_with_settings(addon_cls, tmp_path, {
+            "extra_hosts": {"good.corp": "10.0.0.1", "bad.corp": "not-an-ip"},
+        })
+        assert "10.0.0.1\tgood.corp" in content
+        assert "bad.corp" not in content
+
+    def test_invalid_hostname_skipped(self, addon_cls, tmp_path):
+        content = self._load_with_settings(addon_cls, tmp_path, {
+            "extra_hosts": {"bad host!": "10.0.0.1", "good.corp": "10.0.0.2"},
+        })
+        assert "10.0.0.2\tgood.corp" in content
+        assert "bad host!" not in content
+
+    def test_non_string_value_skipped(self, addon_cls, tmp_path):
+        content = self._load_with_settings(addon_cls, tmp_path, {
+            "extra_hosts": {"numeric.corp": 42, "good.corp": "10.0.0.2"},
+        })
+        assert "10.0.0.2\tgood.corp" in content
+        assert "numeric.corp" not in content
+
+    def test_trailing_dot_in_hostname_normalised(self, addon_cls, tmp_path):
+        # FQDN with trailing dot is a common convention; the addon strips it
+        # before regex validation so `nexus.corp.` is stored as `nexus.corp`.
+        content = self._load_with_settings(addon_cls, tmp_path, {
+            "extra_hosts": {"nexus.corp.": "10.0.0.1"},
+        })
+        assert "10.0.0.1\tnexus.corp" in content
+        assert "nexus.corp." not in content
+
+    def test_disable_branch_truncates_stale_extra_hosts(self, addon_cls, tmp_path):
+        # When the addon disables itself (no settings files present) it MUST
+        # still truncate any pre-existing extra_hosts sidecar so wg-client
+        # cannot re-apply stale mappings from a previous run.
+        hosts_path = tmp_path / "extra_hosts"
+        hosts_path.write_text("10.0.0.5\tstale.corp\n")  # simulate leftover
+        addon = addon_cls()
+        with patch(f"{_COMMON}.SETTINGS_PATHS", [str(tmp_path / "does-not-exist.json")]), \
+             patch(f"{_COMMON}.SANDCAT_ENV_PATH", str(tmp_path / "sandcat.env")), \
+             patch(f"{_COMMON}.SANDCAT_DNS_CONF_PATH", str(tmp_path / "dns.conf")), \
+             patch(f"{_COMMON}.CURSOR_CLI_CONFIG_PATH", str(tmp_path / "cursor-cli-config.json")), \
+             patch(f"{_COMMON}.EXTRA_HOSTS_PATH", str(hosts_path)):
+            addon.load(MagicMock())
+        assert hosts_path.read_text() == "", "disable branch must truncate stale entries"
 
 # ---------------------------------------------------------------------------
 # Multi-file loading — exercises the shared layer-reading loop.


### PR DESCRIPTION
Maps hostname → IP in settings.json (user/project/local layers, merged with higher precedence winning). The mitmproxy addon writes entries to the shared mitmproxy-config volume, and wg-client appends them to /etc/hosts inside a sentinel block at startup; the agent inherits the file via network_mode: service:wg-client. Resolves #54.