### PR TITLE
feat(cli): expand Cursor host mounts, Sandcat-controlled CLI config, and workspace isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,73 @@ Selecting `scala` automatically includes `java` as a dependency. Stacks also
 install the corresponding VS Code extension (e.g. `rust-analyzer` for Rust,
 `metals` for Scala).
 
-Optional volume mounts (agent config, .git, .idea) are configurable in the
-generated compose file. Agent config mounts are active by default for the
-selected agent; .git and .idea are commented out. Set `SANDCAT_*` environment
-variables for scripted usage. See the [CLI README](cli/README.md) for the full
-list of flags and environment variables.
+Optional volume mounts (agent config, `.git`, `.idea`) are written into the
+generated `.devcontainer/compose-all.yml`. See [Customizing optional volume
+mounts](#customizing-optional-volume-mounts) below. For scripted `sandcat init`,
+set `SANDCAT_*` environment variables (see the [CLI README](cli/README.md)).
+
+#### Customizing optional volume mounts
+
+`sandcat init` adds optional bind-mounts to `services.agent.volumes` in
+`.devcontainer/compose-all.yml`. Each mount is an independent line — you can
+enable or disable **individual paths** by editing that file after init. This
+works the same way for Claude and Cursor; there are no per-folder `sandcat init`
+flags today.
+
+**All-or-nothing at init time** (scripted workflows only):
+
+| Agent     | Environment variable          | Default                                 |
+|-----------|-------------------------------|-----------------------------------------|
+| Claude    | `SANDCAT_MOUNT_CLAUDE_CONFIG` | `true`                                  |
+| Cursor    | `SANDCAT_MOUNT_CURSOR_CONFIG` | `true`                                  |
+| Any       | `SANDCAT_MOUNT_GIT_READONLY`  | `false` (commented in compose)          |
+| JetBrains | `SANDCAT_MOUNT_IDEA_READONLY` | `false` (active when `--ide jetbrains`) |
+
+When an agent mount flag is `false`, Sandcat lists every path as a foot comment
+on the first volume entry — copy the lines you want into the active `volumes:`
+list.
+
+**Per-path tuning (recommended):** edit `.devcontainer/compose-all.yml`, remove
+or comment out mounts you do not want, then rebuild/reopen the devcontainer:
+
+```yaml
+# Disable a shared Cursor plugins cache on the host:
+# - ${HOME}/.cursor/plugins:/home/vscode/.cursor/plugins
+```
+
+**Do not re-run `sandcat init`** unless you intend to reset generated files —
+it recopies the template and overwrites manual compose edits. Commit your
+customized `compose-all.yml` to keep changes across the team.
+
+**Claude paths** (host `~/.claude/`, read-only when mounted):
+
+- `CLAUDE.md`, `agents/`, `commands/`
+
+**Cursor paths** (host `~/.cursor/`):
+
+| Path                                                                                         | Mode       | Typical use                           |
+|----------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `AGENTS.md`, `rules/`, `skills/`, `commands/`, `hooks.json`, `hooks/`, `agents/`, `mcp.json` | read-only  | Shared customization                  |
+| `projects/`, `chats/`, `plugins/`, `subagents/`                                              | read-write | History and runtime state on the host |
+
+Cursor CLI keys Sandcat manages (`cursor.cli` in settings) are **not**
+host-mounted — see the Cursor section below.
+
+**Project-local config** (per repository, via the workspace code mount — not
+controlled by `SANDCAT_MOUNT_*_CONFIG`):
+
+- Claude: `.claude/` in the repo (skills, agents, etc.)
+- Cursor: `.cursor/` in the repo (rules, skills, agents, `cli.json`, etc.)
+
+Use host mounts for personal defaults shared across sandboxes; use repo
+`.claude/` or `.cursor/` for project-specific or team-shared customization.
+
+**Isolation notes:** host `~/.claude/` and `~/.cursor/` are a single profile per
+user on the machine — all sandcat projects on that host see the same mounted
+trees. Cursor namespaces transcripts under `projects/<workspace-id>/`; chats
+use separate hash directories. To keep a sandcat project fully isolated from
+host agent state, set `SANDCAT_MOUNT_<AGENT>_CONFIG=false` and rely on repo-local
+config plus the `agent-home` volume inside the container.
 
 ### 3. Start the sandbox
 
@@ -569,16 +631,29 @@ Cursor CLI support is available via `sandcat init --agent cursor`.
   These defaults are conservative and may be relaxed when Cursor proxy behavior
   is consistently stable across environments.
 - Use `CURSOR_API_KEY` in your user settings for Cursor authentication.
-- On container startup, Sandcat writes
-  `.network.useHttp1ForAgent = true` to
-  `~/.config/cursor/cli-config.json` (`~/.cursor/cli-config.json` is also
-  updated for compatibility).
-- `SANDCAT_MOUNT_CURSOR_CONFIG=true` mounts `~/.cursor/AGENTS.md`,
-  `~/.cursor/rules`, `~/.cursor/skills`, `~/.cursor/commands`,
-  `~/.cursor/hooks.json`, `~/.cursor/hooks`, and `~/.cursor/agents` into the
-  agent container (read-only). User-level MCP config (`~/.cursor/mcp.json`,
-  `~/.cursor/plugins/local`, etc.) is not mounted yet; treat MCP + mitmproxy
-  allowlists as a separate change if you need them in the sandbox.
+- **Cursor CLI config via Sandcat settings:** add a `cursor.cli` block to
+  `~/.config/sandcat/settings.json` (or project `.sandcat/settings.json`) using
+  the same JSON shape as Cursor's global `cli-config.json`. Sandcat merges
+  settings layers at mitmproxy startup, writes
+  `/mitmproxy-config/cursor-cli-config.json`, and the agent deep-merges that
+  fragment into `cli-config.json` in `agent-home` on each start. Sandcat-owned
+  keys win; Cursor-managed keys (model, permissions, auth) persist in
+  `agent-home`. The Cursor user template defaults include
+  `cursor.cli.network.useHttp1ForAgent: true` for mitmproxy stability.
+- `SANDCAT_MOUNT_CURSOR_CONFIG=true` mounts host Cursor config into the agent
+  container. Customization paths are read-only: `AGENTS.md`, `rules/`, `skills/`,
+  `commands/`, `hooks.json`, `hooks/`, `agents/`, and `mcp.json`. Runtime state
+  is read-write on the host: `projects/` (agent transcripts, terminals, MCP
+  session state), `chats/`, `plugins/`, and `subagents/`. On `sandcat init`,
+  missing bind sources are pre-created on the host (directories via `mkdir`,
+  JSON files with minimal valid defaults, markdown files empty) so Docker mounts
+  a file instead of materialising a root-owned directory.
+- **Config precedence:** `~/.config/sandcat/settings.json` governs network
+  allowlists, secret substitution (mitmproxy), and Sandcat-managed Cursor CLI
+  keys (`cursor.cli`). Host Cursor customization mounts are read-only user
+  config. Runtime history mounts (`projects/`, `chats/`, etc.) are read-write on
+  the host. MCP servers in `mcp.json` still need matching mitmproxy allowlist
+  entries before they can reach the network from the sandbox.
 - **Cursor CLI TLS through mitmproxy.** The Cursor CLI bundles its own Node.js
   binary with compiled-in Mozilla CA roots. Sandcat sets
   `NODE_OPTIONS=--use-openssl-ca` so the bundled Node.js uses the system CA
@@ -664,8 +739,10 @@ flowchart TB
   containers never see real secrets. The user settings file
   (`~/.config/sandcat/settings.json`) and the project settings directory
   (`.sandcat/`) are both mounted read-only.
-- **Claude Code customizations** (`CLAUDE.md`, `agents/`, `commands/`) are
-  bind-mounted from the host into the app container read-only.
+- **Claude Code customizations** (`CLAUDE.md`, `agents/`, `commands/`) and
+  **Cursor host config** (`~/.cursor/*` — see Cursor section above) are
+  bind-mounted from the host when enabled in `compose-all.yml`. Per-path toggles
+  are described in [Customizing optional volume mounts](#customizing-optional-volume-mounts).
 
 ### Startup sequence
 

--- a/README.md
+++ b/README.md
@@ -574,7 +574,11 @@ Cursor CLI support is available via `sandcat init --agent cursor`.
   `~/.config/cursor/cli-config.json` (`~/.cursor/cli-config.json` is also
   updated for compatibility).
 - `SANDCAT_MOUNT_CURSOR_CONFIG=true` mounts `~/.cursor/AGENTS.md`,
-  `~/.cursor/rules`, and `~/.cursor/skills` into the agent container.
+  `~/.cursor/rules`, `~/.cursor/skills`, `~/.cursor/commands`,
+  `~/.cursor/hooks.json`, `~/.cursor/hooks`, and `~/.cursor/agents` into the
+  agent container (read-only). User-level MCP config (`~/.cursor/mcp.json`,
+  `~/.cursor/plugins/local`, etc.) is not mounted yet; treat MCP + mitmproxy
+  allowlists as a separate change if you need them in the sandbox.
 - **Cursor CLI TLS through mitmproxy.** The Cursor CLI bundles its own Node.js
   binary with compiled-in Mozilla CA roots. Sandcat sets
   `NODE_OPTIONS=--use-openssl-ca` so the bundled Node.js uses the system CA

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ list.
 or comment out mounts you do not want, then rebuild/reopen the devcontainer:
 
 ```yaml
-# Disable a shared Cursor plugins cache on the host:
-# - ${HOME}/.cursor/plugins:/home/vscode/.cursor/plugins
+# Mount a different workspace's Cursor transcripts (not recommended):
+# - ${HOME}/.cursor/projects/workspaces-other-project:/home/vscode/.cursor/projects/workspaces-other-project
 ```
 
 **Do not re-run `sandcat init`** unless you intend to reset generated files —
@@ -159,7 +159,12 @@ customized `compose-all.yml` to keep changes across the team.
 | Path                                                                                         | Mode       | Typical use                           |
 |----------------------------------------------------------------------------------------------|------------|---------------------------------------|
 | `AGENTS.md`, `rules/`, `skills/`, `commands/`, `hooks.json`, `hooks/`, `agents/`, `mcp.json` | read-only  | Shared customization                  |
-| `projects/`, `chats/`, `plugins/`, `subagents/`                                              | read-write | History and runtime state on the host |
+| `projects/<workspace-id>/`                                                                   | read-write | This sandbox's transcripts/terminals  |
+
+Sandcat mounts only `projects/<workspace-id>/` for the current sandbox
+(`workspaces-<project-name>`), not the whole host `projects/` tree. `chats/`,
+`plugins/`, and `subagents/` stay in `agent-home` so other workspaces' runtime
+state is not exposed.
 
 Cursor CLI keys Sandcat manages (`cursor.cli` in settings) are **not**
 host-mounted — see the Cursor section below.
@@ -173,12 +178,14 @@ controlled by `SANDCAT_MOUNT_*_CONFIG`):
 Use host mounts for personal defaults shared across sandboxes; use repo
 `.claude/` or `.cursor/` for project-specific or team-shared customization.
 
-**Isolation notes:** host `~/.claude/` and `~/.cursor/` are a single profile per
-user on the machine — all sandcat projects on that host see the same mounted
-trees. Cursor namespaces transcripts under `projects/<workspace-id>/`; chats
-use separate hash directories. To keep a sandcat project fully isolated from
-host agent state, set `SANDCAT_MOUNT_<AGENT>_CONFIG=false` and rely on repo-local
-config plus the `agent-home` volume inside the container.
+**Isolation notes:** host `~/.claude/` and shared Cursor customization mounts
+(`rules/`, `skills/`, etc.) are one profile per user on the machine — all
+sandcat projects on that host see the same mounted trees. Cursor transcripts for
+this sandbox persist under host `projects/<workspace-id>/` only
+(`workspaces-<project-name>`). Other workspaces' `projects/`, plus `chats/`,
+`plugins/`, and `subagents/`, are not mounted. To keep a sandcat project fully
+isolated from host agent state, set `SANDCAT_MOUNT_<AGENT>_CONFIG=false` and
+rely on repo-local config plus the `agent-home` volume inside the container.
 
 ### 3. Start the sandbox
 
@@ -630,30 +637,39 @@ Cursor CLI support is available via `sandcat init --agent cursor`.
     header bypass body substitution and the placeholder leak check.
   These defaults are conservative and may be relaxed when Cursor proxy behavior
   is consistently stable across environments.
-- Use `CURSOR_API_KEY` in your user settings for Cursor authentication.
-- **Cursor CLI config via Sandcat settings:** add a `cursor.cli` block to
+- **Authentication:** put the Cursor API key in `secrets.CURSOR_API_KEY` in
+  Sandcat settings (not in `cursor.cli`). The agent container receives only
+  `SANDCAT_PLACEHOLDER_CURSOR_API_KEY` via `sandcat.env`; mitmproxy substitutes
+  the real key on allowed Cursor hosts (see placeholder substitution above).
+  Do not use `agent login` in the sandbox unless you accept that Cursor may
+  store session state under agent-home outside Sandcat's placeholder model.
+- **Cursor CLI settings via Sandcat:** add a `cursor.cli` block to
   `~/.config/sandcat/settings.json` (or project `.sandcat/settings.json`) using
-  the same JSON shape as Cursor's global `cli-config.json`. Sandcat merges
-  settings layers at mitmproxy startup, writes
-  `/mitmproxy-config/cursor-cli-config.json`, and the agent deep-merges that
-  fragment into `cli-config.json` in `agent-home` on each start. Sandcat-owned
-  keys win; Cursor-managed keys (model, permissions, auth) persist in
-  `agent-home`. The Cursor user template defaults include
-  `cursor.cli.network.useHttp1ForAgent: true` for mitmproxy stability.
+  the same JSON shape as Cursor's global `cli-config.json` (permissions, model,
+  network flags — not API keys). Sandcat merges settings layers at mitmproxy
+  startup, writes `/mitmproxy-config/cursor-cli-config.json`, and the agent
+  deep-merges that fragment into `cli-config.json` in agent-home on each start.
+  Sandcat-owned keys win; other Cursor-written keys in that file (model choice,
+  permissions allow/deny lists, etc.) are preserved. The Cursor user template
+  defaults include `cursor.cli.network.useHttp1ForAgent: true` for mitmproxy
+  stability.
 - `SANDCAT_MOUNT_CURSOR_CONFIG=true` mounts host Cursor config into the agent
   container. Customization paths are read-only: `AGENTS.md`, `rules/`, `skills/`,
   `commands/`, `hooks.json`, `hooks/`, `agents/`, and `mcp.json`. Runtime state
-  is read-write on the host: `projects/` (agent transcripts, terminals, MCP
-  session state), `chats/`, `plugins/`, and `subagents/`. On `sandcat init`,
-  missing bind sources are pre-created on the host (directories via `mkdir`,
-  JSON files with minimal valid defaults, markdown files empty) so Docker mounts
-  a file instead of materialising a root-owned directory.
+  for this sandbox is read-write on the host under
+  `projects/<workspace-id>/` only (`workspaces-<project-name>` — agent
+  transcripts, terminals, MCP session state). `chats/`, `plugins/`, and
+  `subagents/` are not host-mounted (they live in `agent-home`). On
+  `sandcat init`, missing bind sources are pre-created on the host (directories
+  via `mkdir`, JSON files with minimal valid defaults, markdown files empty) so
+  Docker mounts a file instead of materialising a root-owned directory.
 - **Config precedence:** `~/.config/sandcat/settings.json` governs network
   allowlists, secret substitution (mitmproxy), and Sandcat-managed Cursor CLI
-  keys (`cursor.cli`). Host Cursor customization mounts are read-only user
-  config. Runtime history mounts (`projects/`, `chats/`, etc.) are read-write on
-  the host. MCP servers in `mcp.json` still need matching mitmproxy allowlist
-  entries before they can reach the network from the sandbox.
+  settings (`cursor.cli` — not credentials). Host Cursor customization mounts
+  are read-only user config. The workspace-scoped `projects/<workspace-id>/`
+  mount is read-write on the host. MCP servers in `mcp.json` still need
+  matching mitmproxy allowlist entries before they can reach the network from
+  the sandbox.
 - **Cursor CLI TLS through mitmproxy.** The Cursor CLI bundles its own Node.js
   binary with compiled-in Mozilla CA roots. Sandcat sets
   `NODE_OPTIONS=--use-openssl-ca` so the bundled Node.js uses the system CA

--- a/cli/README.md
+++ b/cli/README.md
@@ -90,10 +90,10 @@ docker build \
 
 PAT detection relies on the wording of `pass-cli info` output. Because the binary is pinned by version **and** sha256, that output cannot change without a deliberate bump. A contract test (`TestPassCliPatContract`) locks the detection regex against golden samples tagged with `PASS_CLI_VERSION`. When you bump `pass-cli.env`, you must also re-capture those samples — see [`cli/test/mitmproxy/fixtures/pass-cli/README.md`](test/mitmproxy/fixtures/pass-cli/README.md) — or CI will fail.
 
-Note: Cursor agent support currently uses compatibility defaults for auth/network
-settings while provider-specific hardening is being expanded.
-Use `CURSOR_API_KEY` for Cursor authentication.
-Sandcat always bootstraps Cursor CLI with `.network.useHttp1ForAgent = true`.
+Note: Cursor agent support uses placeholder-based API key substitution and
+Sandcat-managed CLI settings (`cursor.cli` in settings — permissions, model,
+network flags). Put the API key in `secrets.CURSOR_API_KEY`, not in
+`cursor.cli`. See the main README Cursor section for details.
 
 #### `sandcat init devcontainer`
 
@@ -214,9 +214,11 @@ editing `.devcontainer/compose-all.yml` after init. See the main
 
 - `SANDCAT_MOUNT_CLAUDE_CONFIG` - `true` to mount host `~/.claude` config (Claude agent only)
 - `SANDCAT_MOUNT_CURSOR_CONFIG` - `true` to mount host `~/.cursor` customization
-  (read-only) and runtime state (read-write: `projects/`, `chats/`, `plugins/`,
-  `subagents/`) into the agent container (Cursor agent only). Cursor CLI keys
-  Sandcat manages (`cursor.cli` in settings) are merged into agent-home
-  `cli-config.json` at container startup — not host-mounted.
+  (read-only) and workspace-scoped runtime state (read-write:
+  `projects/<workspace-id>/` only) into the agent container (Cursor agent
+  only). `chats/`, `plugins/`, and `subagents/` stay in agent-home. Sandcat
+  CLI settings (`cursor.cli` — not API keys) are merged into agent-home
+  `cli-config.json` at container startup — not host-mounted. API keys belong
+  in `secrets.CURSOR_API_KEY` and are substituted by mitmproxy.
 - `SANDCAT_MOUNT_GIT_READONLY` - `true` to mount `.git/` directory as read-only
 - `SANDCAT_MOUNT_IDEA_READONLY` - `true` to mount `.idea/` directory as read-only (JetBrains)

--- a/cli/README.md
+++ b/cli/README.md
@@ -208,7 +208,15 @@ cli/
 These override defaults during compose file generation. Optional volumes default to `false` (commented out),
 except provider config mounts, which default to `true` for the selected agent.
 
+Per-folder mounts are **not** separate init flags — tune individual paths by
+editing `.devcontainer/compose-all.yml` after init. See the main
+[README section on customizing optional volume mounts](../README.md#customizing-optional-volume-mounts).
+
 - `SANDCAT_MOUNT_CLAUDE_CONFIG` - `true` to mount host `~/.claude` config (Claude agent only)
-- `SANDCAT_MOUNT_CURSOR_CONFIG` - `true` to mount host `~/.cursor` config (Cursor agent only)
+- `SANDCAT_MOUNT_CURSOR_CONFIG` - `true` to mount host `~/.cursor` customization
+  (read-only) and runtime state (read-write: `projects/`, `chats/`, `plugins/`,
+  `subagents/`) into the agent container (Cursor agent only). Cursor CLI keys
+  Sandcat manages (`cursor.cli` in settings) are merged into agent-home
+  `cli-config.json` at container startup — not host-mounted.
 - `SANDCAT_MOUNT_GIT_READONLY` - `true` to mount `.git/` directory as read-only
 - `SANDCAT_MOUNT_IDEA_READONLY` - `true` to mount `.idea/` directory as read-only (JetBrains)

--- a/cli/lib/agents.bash
+++ b/cli/lib/agents.bash
@@ -36,9 +36,11 @@ sct_agent_mount_env_var() {
 # bind source as a root-owned empty directory in the user's $HOME — annoying
 # to clean up and confusing because the directory shows up out of nowhere.
 #
-# Each path on its own line. Lines ending with '/' are treated as directories,
-# everything else as files (touch -a). Pre-creating only happens when the
-# agent's mount env var is "true" (or unset, which defaults to true via
+# Each path on its own line. Lines ending with '/' are treated as directories.
+# Files are created when missing; JSON config files get minimal valid defaults
+# (empty files break Cursor CLI parsing and Sandcat's jq bootstrap). Markdown
+# files (AGENTS.md, CLAUDE.md) may remain empty. Pre-creating only happens when
+# the agent's mount env var is "true" (or unset, which defaults to true via
 # customize_compose_file).
 #
 # Args:
@@ -60,12 +62,60 @@ $HOME/.cursor/skills/
 $HOME/.cursor/commands/
 $HOME/.cursor/agents/
 $HOME/.cursor/hooks/
+$HOME/.cursor/projects/
+$HOME/.cursor/chats/
+$HOME/.cursor/plugins/
+$HOME/.cursor/subagents/
 $HOME/.cursor/AGENTS.md
 $HOME/.cursor/hooks.json
+$HOME/.cursor/mcp.json
 EOF
 			;;
 		*)
 			echo ""
+			;;
+	esac
+}
+
+# Creates a host config file when missing or zero-length. Existing non-empty
+# files are left untouched (atime-only touch). JSON files get minimal valid
+# defaults so Docker bind-mounts a file, not a directory, and Cursor CLI can
+# parse the mount target.
+#
+# Args:
+#   $1 - Agent name
+#   $2 - Absolute path to the file
+_ensure_host_agent_config_file() {
+	local agent=$1
+	local path=$2
+
+	if [[ -s "$path" ]]; then
+		touch -a "$path"
+		return 0
+	fi
+
+	case "$agent" in
+		cursor)
+			case "$(basename "$path")" in
+			cli-config.json)
+				printf '%s\n' '{"version":1}' >"$path"
+				;;
+			hooks.json)
+				printf '%s\n' '{"hooks":{}}' >"$path"
+				;;
+			mcp.json)
+				printf '%s\n' '{"mcpServers":{}}' >"$path"
+				;;
+			AGENTS.md)
+				: >"$path"
+				;;
+			*)
+				: >"$path"
+				;;
+			esac
+			;;
+		*)
+			: >"$path"
 			;;
 	esac
 }
@@ -100,9 +150,7 @@ ensure_host_agent_config_paths() {
 			mkdir -p "${expanded%/}"
 		else
 			mkdir -p "$(dirname "$expanded")"
-			# touch -a updates atime only; creates the file if missing
-			# without bumping mtime when it already exists.
-			touch -a "$expanded"
+			_ensure_host_agent_config_file "$agent" "$expanded"
 		fi
 	done < <(sct_agent_host_config_paths "$agent")
 }
@@ -323,24 +371,33 @@ EOF
 # Cursor auth uses the placeholder value from sandcat.env. The mitmproxy addon
 # substitutes it with the real secret on allowed outbound Cursor requests.
 
-# Cursor CLI networking bootstrap.
-# Some proxy/TLS environments are unstable with HTTP/2 streaming, so always
-# enforce the Cursor CLI HTTP/1 compatibility setting.
-if command -v jq >/dev/null 2>&1; then
-    for CURSOR_CLI_CONFIG in "$HOME/.config/cursor/cli-config.json" "$HOME/.cursor/cli-config.json"; do
-        mkdir -p "$(dirname "$CURSOR_CLI_CONFIG")"
-        if [ ! -f "$CURSOR_CLI_CONFIG" ]; then
-            echo '{"version":1}' > "$CURSOR_CLI_CONFIG"
-        fi
-        tmp="$(mktemp)"
-        jq \
-            '.network = (.network // {}) | .network.useHttp1ForAgent = true' \
-            "$CURSOR_CLI_CONFIG" > "$tmp" \
-            && mv "$tmp" "$CURSOR_CLI_CONFIG" \
-            || { rm -f "$tmp"; echo "Warning: failed to update $CURSOR_CLI_CONFIG via jq" >&2; }
-    done
+# Apply Sandcat-managed Cursor CLI settings. mitmproxy merges settings.json
+# `cursor.cli` at startup and writes /mitmproxy-config/cursor-cli-config.json;
+# deep-merge that fragment into agent-home cli-config.json so Sandcat-owned
+# keys win while Cursor-managed keys (model, permissions, auth) persist.
+SANDCAT_CURSOR_CLI="/mitmproxy-config/cursor-cli-config.json"
+if [ -f "$SANDCAT_CURSOR_CLI" ] && command -v jq >/dev/null 2>&1; then
+    sandcat_cli="$(jq -c 'if type == "object" then . else {} end' "$SANDCAT_CURSOR_CLI" 2>/dev/null || echo '{}')"
+    if [ "$sandcat_cli" != "{}" ] && [ -n "$sandcat_cli" ]; then
+        for CURSOR_CLI_CONFIG in "$HOME/.config/cursor/cli-config.json" "$HOME/.cursor/cli-config.json"; do
+            mkdir -p "$(dirname "$CURSOR_CLI_CONFIG")"
+            if [ ! -s "$CURSOR_CLI_CONFIG" ]; then
+                echo '{}' > "$CURSOR_CLI_CONFIG"
+            fi
+            tmp="$(mktemp)"
+            if jq -s '.[0] * .[1]' "$CURSOR_CLI_CONFIG" <(echo "$sandcat_cli") > "$tmp"; then
+                cat "$tmp" > "$CURSOR_CLI_CONFIG" \
+                    || echo "Warning: failed to apply Sandcat cursor.cli to $CURSOR_CLI_CONFIG" >&2
+            else
+                echo "Warning: failed to merge Sandcat cursor.cli into $CURSOR_CLI_CONFIG" >&2
+            fi
+            rm -f "$tmp"
+        done
+    fi
 else
-    echo "Warning: jq not found; cannot apply Cursor CLI HTTP/1 bootstrap config" >&2
+    if [ -f "$SANDCAT_CURSOR_CLI" ]; then
+        echo "Warning: jq not found; cannot apply Sandcat cursor.cli settings" >&2
+    fi
 fi
 EOF
 			;;

--- a/cli/lib/agents.bash
+++ b/cli/lib/agents.bash
@@ -57,7 +57,11 @@ EOF
 			cat <<'EOF'
 $HOME/.cursor/rules/
 $HOME/.cursor/skills/
+$HOME/.cursor/commands/
+$HOME/.cursor/agents/
+$HOME/.cursor/hooks/
 $HOME/.cursor/AGENTS.md
+$HOME/.cursor/hooks.json
 EOF
 			;;
 		*)

--- a/cli/lib/agents.bash
+++ b/cli/lib/agents.bash
@@ -19,6 +19,18 @@ sct_is_valid_agent() {
 	return 1
 }
 
+# Maps sandcat project_name to Cursor's ~/.cursor/projects/<id> directory.
+# Cursor encodes the workspace path /workspaces/<name> by dropping the leading
+# slash and replacing path separators with hyphens (e.g. workspaces-foo-bar).
+#
+# Args:
+#   $1 - Sandcat project name (workspace is /workspaces/<name>)
+sct_cursor_workspace_project_id() {
+	local project_name=$1
+	local workspace="/workspaces/$project_name"
+	printf '%s' "${workspace#/}" | tr '/' '-'
+}
+
 # Returns the optional config mount env var for an agent.
 # Args:
 #   $1 - Agent name
@@ -45,8 +57,10 @@ sct_agent_mount_env_var() {
 #
 # Args:
 #   $1 - Agent name
+#   $2 - Sandcat project name (required for cursor workspace-scoped paths)
 sct_agent_host_config_paths() {
 	local agent=$1
+	local project_name=${2:-}
 	case "$agent" in
 		claude)
 			cat <<'EOF'
@@ -56,19 +70,18 @@ $HOME/.claude/CLAUDE.md
 EOF
 			;;
 		cursor)
-			cat <<'EOF'
-$HOME/.cursor/rules/
-$HOME/.cursor/skills/
-$HOME/.cursor/commands/
-$HOME/.cursor/agents/
-$HOME/.cursor/hooks/
-$HOME/.cursor/projects/
-$HOME/.cursor/chats/
-$HOME/.cursor/plugins/
-$HOME/.cursor/subagents/
-$HOME/.cursor/AGENTS.md
-$HOME/.cursor/hooks.json
-$HOME/.cursor/mcp.json
+			local project_id
+			project_id=$(sct_cursor_workspace_project_id "$project_name")
+			cat <<EOF
+\$HOME/.cursor/rules/
+\$HOME/.cursor/skills/
+\$HOME/.cursor/commands/
+\$HOME/.cursor/agents/
+\$HOME/.cursor/hooks/
+\$HOME/.cursor/projects/${project_id}/
+\$HOME/.cursor/AGENTS.md
+\$HOME/.cursor/hooks.json
+\$HOME/.cursor/mcp.json
 EOF
 			;;
 		*)
@@ -126,8 +139,10 @@ _ensure_host_agent_config_file() {
 #
 # Args:
 #   $1 - Agent name
+#   $2 - Sandcat project name (used for cursor workspace-scoped host paths)
 ensure_host_agent_config_paths() {
 	local agent=$1
+	local project_name=${2:-}
 	local mount_var
 	mount_var=$(sct_agent_mount_env_var "$agent")
 	if [[ -z "$mount_var" ]]; then
@@ -152,7 +167,7 @@ ensure_host_agent_config_paths() {
 			mkdir -p "$(dirname "$expanded")"
 			_ensure_host_agent_config_file "$agent" "$expanded"
 		fi
-	done < <(sct_agent_host_config_paths "$agent")
+	done < <(sct_agent_host_config_paths "$agent" "$project_name")
 }
 
 # Returns one-line API key help text for init output.
@@ -374,7 +389,8 @@ EOF
 # Apply Sandcat-managed Cursor CLI settings. mitmproxy merges settings.json
 # `cursor.cli` at startup and writes /mitmproxy-config/cursor-cli-config.json;
 # deep-merge that fragment into agent-home cli-config.json so Sandcat-owned
-# keys win while Cursor-managed keys (model, permissions, auth) persist.
+# keys win while other Cursor-written keys (model, permissions, etc.) persist.
+# API keys belong in secrets.CURSOR_API_KEY — not cursor.cli or cli-config.json.
 SANDCAT_CURSOR_CLI="/mitmproxy-config/cursor-cli-config.json"
 if [ -f "$SANDCAT_CURSOR_CLI" ] && command -v jq >/dev/null 2>&1; then
     sandcat_cli="$(jq -c 'if type == "object" then . else {} end' "$SANDCAT_CURSOR_CLI" 2>/dev/null || echo '{}')"

--- a/cli/lib/composefile.bash
+++ b/cli/lib/composefile.bash
@@ -13,8 +13,11 @@ source "$SCT_LIBDIR/agents.bash"
 # Optional volumes are added as commented-out entries by default. Set environment
 # variables to "true" before calling this function to add them as active mounts:
 #   - SANDCAT_MOUNT_CLAUDE_CONFIG: "true" to mount host Claude config (~/.claude)
-#   - SANDCAT_MOUNT_CURSOR_CONFIG: "true" to mount host Cursor config (~/.cursor:
-#     AGENTS.md, rules/, skills/, commands/, hooks.json, hooks/, agents/)
+#   - SANDCAT_MOUNT_CURSOR_CONFIG: "true" to mount host Cursor config (~/.cursor
+#     customization read-only; projects/, chats/, plugins/, subagents/ read-write;
+#     mcp.json read-only). cli-config.json stays in agent-home — Sandcat injects
+#     sandbox-specific keys at container startup and bind-mounting the file breaks
+#     atomic updates across filesystems.
 #   - SANDCAT_MOUNT_GIT_READONLY: "true" to mount .git directory as read-only
 #   - SANDCAT_MOUNT_IDEA_READONLY: "true" to mount .idea directory as read-only
 # Args:
@@ -263,6 +266,19 @@ add_cursor_config_volumes() {
 	add_volume_entry "$compose_file" '${HOME}/.cursor/hooks:/home/vscode/.cursor/hooks:ro' "$active"
 	# shellcheck disable=SC2016
 	add_volume_entry "$compose_file" '${HOME}/.cursor/agents:/home/vscode/.cursor/agents:ro' "$active"
+	# shellcheck disable=SC2016
+	add_volume_entry "$compose_file" '${HOME}/.cursor/mcp.json:/home/vscode/.cursor/mcp.json:ro' "$active"
+	# Runtime state — read-write so agent history persists on the host across
+	# agent-home volume recreation. cli-config.json is intentionally not mounted:
+	# Sandcat merges sandbox keys (useHttp1ForAgent) at startup into agent-home.
+	# shellcheck disable=SC2016
+	add_volume_entry "$compose_file" '${HOME}/.cursor/projects:/home/vscode/.cursor/projects' "$active"
+	# shellcheck disable=SC2016
+	add_volume_entry "$compose_file" '${HOME}/.cursor/chats:/home/vscode/.cursor/chats' "$active"
+	# shellcheck disable=SC2016
+	add_volume_entry "$compose_file" '${HOME}/.cursor/plugins:/home/vscode/.cursor/plugins' "$active"
+	# shellcheck disable=SC2016
+	add_volume_entry "$compose_file" '${HOME}/.cursor/subagents:/home/vscode/.cursor/subagents' "$active"
 }
 
 

--- a/cli/lib/composefile.bash
+++ b/cli/lib/composefile.bash
@@ -13,7 +13,8 @@ source "$SCT_LIBDIR/agents.bash"
 # Optional volumes are added as commented-out entries by default. Set environment
 # variables to "true" before calling this function to add them as active mounts:
 #   - SANDCAT_MOUNT_CLAUDE_CONFIG: "true" to mount host Claude config (~/.claude)
-#   - SANDCAT_MOUNT_CURSOR_CONFIG: "true" to mount host Cursor config (~/.cursor)
+#   - SANDCAT_MOUNT_CURSOR_CONFIG: "true" to mount host Cursor config (~/.cursor:
+#     AGENTS.md, rules/, skills/, commands/, hooks.json, hooks/, agents/)
 #   - SANDCAT_MOUNT_GIT_READONLY: "true" to mount .git directory as read-only
 #   - SANDCAT_MOUNT_IDEA_READONLY: "true" to mount .idea directory as read-only
 # Args:
@@ -254,6 +255,14 @@ add_cursor_config_volumes() {
 	add_volume_entry "$compose_file" '${HOME}/.cursor/rules:/home/vscode/.cursor/rules:ro' "$active"
 	# shellcheck disable=SC2016
 	add_volume_entry "$compose_file" '${HOME}/.cursor/skills:/home/vscode/.cursor/skills:ro' "$active"
+	# shellcheck disable=SC2016
+	add_volume_entry "$compose_file" '${HOME}/.cursor/commands:/home/vscode/.cursor/commands:ro' "$active"
+	# shellcheck disable=SC2016
+	add_volume_entry "$compose_file" '${HOME}/.cursor/hooks.json:/home/vscode/.cursor/hooks.json:ro' "$active"
+	# shellcheck disable=SC2016
+	add_volume_entry "$compose_file" '${HOME}/.cursor/hooks:/home/vscode/.cursor/hooks:ro' "$active"
+	# shellcheck disable=SC2016
+	add_volume_entry "$compose_file" '${HOME}/.cursor/agents:/home/vscode/.cursor/agents:ro' "$active"
 }
 
 

--- a/cli/lib/composefile.bash
+++ b/cli/lib/composefile.bash
@@ -14,10 +14,10 @@ source "$SCT_LIBDIR/agents.bash"
 # variables to "true" before calling this function to add them as active mounts:
 #   - SANDCAT_MOUNT_CLAUDE_CONFIG: "true" to mount host Claude config (~/.claude)
 #   - SANDCAT_MOUNT_CURSOR_CONFIG: "true" to mount host Cursor config (~/.cursor
-#     customization read-only; projects/, chats/, plugins/, subagents/ read-write;
-#     mcp.json read-only). cli-config.json stays in agent-home — Sandcat injects
-#     sandbox-specific keys at container startup and bind-mounting the file breaks
-#     atomic updates across filesystems.
+#     customization read-only; workspace-scoped projects/<id>/ read-write;
+#     mcp.json read-only). chats/, plugins/, and subagents/ stay in agent-home
+#     so other workspaces' runtime state is not exposed. cli-config.json is
+#     driven by cursor.cli in Sandcat settings (not host-mounted).
 #   - SANDCAT_MOUNT_GIT_READONLY: "true" to mount .git directory as read-only
 #   - SANDCAT_MOUNT_IDEA_READONLY: "true" to mount .idea directory as read-only
 # Args:
@@ -55,7 +55,7 @@ customize_compose_file() {
 			add_claude_config_volumes "$compose_file" "${SANDCAT_MOUNT_CLAUDE_CONFIG:=true}"
 			;;
 		cursor)
-			add_cursor_config_volumes "$compose_file" "${SANDCAT_MOUNT_CURSOR_CONFIG:=true}"
+			add_cursor_config_volumes "$compose_file" "${SANDCAT_MOUNT_CURSOR_CONFIG:=true}" "$project_name"
 			;;
 	esac
 
@@ -248,9 +248,13 @@ add_claude_config_volumes() {
 # Args:
 #   $1 - Path to the Docker Compose file
 #   $2 - true to add as active, false to add as comment
+#   $3 - Sandcat project name (scopes projects/ to this workspace only)
 add_cursor_config_volumes() {
 	local compose_file=$1
-	local active=${2:-true}
+	local active=$2
+	local project_name=$3
+	local project_id
+	project_id=$(sct_cursor_workspace_project_id "$project_name")
 
 	# shellcheck disable=SC2016
 	add_volume_entry "$compose_file" '${HOME}/.cursor/AGENTS.md:/home/vscode/.cursor/AGENTS.md:ro' "$active" 'Host Cursor config (optional)'
@@ -268,17 +272,13 @@ add_cursor_config_volumes() {
 	add_volume_entry "$compose_file" '${HOME}/.cursor/agents:/home/vscode/.cursor/agents:ro' "$active"
 	# shellcheck disable=SC2016
 	add_volume_entry "$compose_file" '${HOME}/.cursor/mcp.json:/home/vscode/.cursor/mcp.json:ro' "$active"
-	# Runtime state — read-write so agent history persists on the host across
-	# agent-home volume recreation. cli-config.json is intentionally not mounted:
-	# Sandcat merges sandbox keys (useHttp1ForAgent) at startup into agent-home.
-	# shellcheck disable=SC2016
-	add_volume_entry "$compose_file" '${HOME}/.cursor/projects:/home/vscode/.cursor/projects' "$active"
-	# shellcheck disable=SC2016
-	add_volume_entry "$compose_file" '${HOME}/.cursor/chats:/home/vscode/.cursor/chats' "$active"
-	# shellcheck disable=SC2016
-	add_volume_entry "$compose_file" '${HOME}/.cursor/plugins:/home/vscode/.cursor/plugins' "$active"
-	# shellcheck disable=SC2016
-	add_volume_entry "$compose_file" '${HOME}/.cursor/subagents:/home/vscode/.cursor/subagents' "$active"
+	# Workspace-scoped runtime state — only this sandcat project's Cursor
+	# projects/<id>/ tree is mounted (agent transcripts, terminals, etc.).
+	# chats/, plugins/, and subagents/ remain in agent-home to avoid leaking
+	# other workspaces' data from the host profile.
+	add_volume_entry "$compose_file" \
+		"\${HOME}/.cursor/projects/${project_id}:/home/vscode/.cursor/projects/${project_id}" \
+		"$active"
 }
 
 

--- a/cli/libexec/init/init
+++ b/cli/libexec/init/init
@@ -339,7 +339,7 @@ init() {
 
 	# Pre-create host paths that the optional agent config mounts will bind,
 	# so Docker doesn't auto-create them as root-owned dirs in the user's home.
-	ensure_host_agent_config_paths "$agent"
+	ensure_host_agent_config_paths "$agent" "$name"
 
 	add_secret_provider_tokens_to_user_settings "$secret_provider"
 

--- a/cli/libexec/init/init
+++ b/cli/libexec/init/init
@@ -76,8 +76,17 @@ ensure_cursor_user_settings_defaults() {
 			(.secrets.CURSOR_API_KEY.hosts // []) +
 			["api.cursor.sh", "api2.cursor.sh", "*.cursor.sh", "*.cursor.com"]
 			| unique
-		)
+		) |
+		.cursor = (.cursor // {}) |
+		.cursor.cli = (.cursor.cli // {}) |
+		.cursor.cli.version = (.cursor.cli.version // 1) |
+		.cursor.cli.network = (.cursor.cli.network // {})
 	' "$user_settings"
+
+	# jq/yq `//` treats false as absent; only default useHttp1ForAgent when missing.
+	if ! yq -e '.cursor.cli.network | has("useHttp1ForAgent")' "$user_settings" >/dev/null 2>&1; then
+		yq -i -o json '.cursor.cli.network.useHttp1ForAgent = true' "$user_settings"
+	fi
 }
 
 # Seeds secret-backend token fields in user settings when missing (idempotent).

--- a/cli/templates/devcontainer/sandcat/scripts/mitmproxy_addon_common.py
+++ b/cli/templates/devcontainer/sandcat/scripts/mitmproxy_addon_common.py
@@ -62,6 +62,7 @@ SETTINGS_PATHS = [
     "/config/project/settings.local.json",  # local:   .sandcat/settings.local.json
 ]
 SANDCAT_ENV_PATH = "/home/mitmproxy/.mitmproxy/sandcat.env"
+CURSOR_CLI_CONFIG_PATH = "/home/mitmproxy/.mitmproxy/cursor-cli-config.json"
 # Sidecar file consumed by wg-client to override /etc/resolv.conf nameservers.
 # One IPv4/IPv6 address per line; empty or missing file means "use defaults".
 # (glibc/musl resolvers reject hostnames in `nameserver` directives.)
@@ -111,6 +112,7 @@ class SandcatAddon:
             # (falling back to defaults) AND so the file's presence still
             # signals "addon has loaded" for the mitmproxy healthcheck.
             self._write_dns_conf()
+            self._write_cursor_cli_config({})
             logger.info("No settings files found — addon disabled")
             return
 
@@ -130,6 +132,7 @@ class SandcatAddon:
         self._load_network_rules(merged["network"])
         self._load_dns_servers(merged["dns_servers"])
         self._write_placeholders_env()
+        self._write_cursor_cli_config(merged)
         self._write_dns_conf()
 
         ctx.log.info(
@@ -281,12 +284,28 @@ class SandcatAddon:
         )
 
     @staticmethod
+    def _deep_merge_dict(base: dict, overlay: dict) -> dict:
+        """Recursively merge overlay into base (overlay wins on conflicts)."""
+        result = dict(base)
+        for key, value in overlay.items():
+            if (
+                key in result
+                and isinstance(result[key], dict)
+                and isinstance(value, dict)
+            ):
+                result[key] = SandcatAddon._deep_merge_dict(result[key], value)
+            else:
+                result[key] = value
+        return result
+
+    @staticmethod
     def _merge_settings(layers: list[dict]) -> dict:
         """Merge settings from multiple layers (lowest to highest precedence).
 
         - env: dict merge, higher precedence overwrites.
         - secrets: dict merge, higher precedence overwrites.
         - network: concatenated, highest precedence first (top-to-bottom matching).
+        - cursor.cli: deep merge, higher precedence overwrites nested keys.
         - op_service_account_token: highest precedence non-empty value wins.
         - dns_servers: highest-precedence layer that sets the key wins (last-wins).
         - proton_pass_token: highest precedence non-empty value wins.
@@ -296,6 +315,7 @@ class SandcatAddon:
         env: dict[str, str] = {}
         secrets: dict[str, dict] = {}
         network: list[dict] = []
+        cursor_cli: dict = {}
         op_token: str | None = None
         dns_servers = None
         proton_pass_token: str | None = None
@@ -303,6 +323,10 @@ class SandcatAddon:
         for layer in layers:
             env.update(layer.get("env", {}))
             secrets.update(layer.get("secrets", {}))
+            layer_cursor = layer.get("cursor", {})
+            layer_cli = layer_cursor.get("cli", {})
+            if layer_cli:
+                cursor_cli = SandcatAddon._deep_merge_dict(cursor_cli, layer_cli)
             layer_token = layer.get("op_service_account_token")
             if layer_token:
                 op_token = layer_token
@@ -320,6 +344,7 @@ class SandcatAddon:
             "env": env,
             "secrets": secrets,
             "network": network,
+            "cursor": {"cli": cursor_cli},
             "op_service_account_token": op_token,
             "dns_servers": dns_servers,
             "proton_pass_token": proton_pass_token,
@@ -577,6 +602,17 @@ class SandcatAddon:
             self._validate_env_name(name)
             lines.append(f'export {name}="{self._shell_escape(entry["placeholder"])}"')
         self._atomic_write_text(SANDCAT_ENV_PATH, "\n".join(lines) + "\n")
+
+    def _write_cursor_cli_config(self, merged: dict):
+        """Publish Sandcat-managed Cursor CLI settings for the agent container.
+
+        The agent deep-merges this fragment into ``cli-config.json`` in
+        agent-home on startup. Keys under ``cursor.cli`` in settings.json use
+        the same shape as Cursor's global ``cli-config.json``.
+        """
+        cli = merged.get("cursor", {}).get("cli", {})
+        body = json.dumps(cli, indent=2) + "\n"
+        self._atomic_write_text(CURSOR_CLI_CONFIG_PATH, body)
 
     @staticmethod
     def _atomic_write_text(path: str, body: str):

--- a/cli/templates/devcontainer/sandcat/scripts/mitmproxy_addon_common.py
+++ b/cli/templates/devcontainer/sandcat/scripts/mitmproxy_addon_common.py
@@ -608,7 +608,8 @@ class SandcatAddon:
 
         The agent deep-merges this fragment into ``cli-config.json`` in
         agent-home on startup. Keys under ``cursor.cli`` in settings.json use
-        the same shape as Cursor's global ``cli-config.json``.
+        the same shape as Cursor's global ``cli-config.json`` (permissions,
+        model, network flags). API keys belong in ``secrets`` — not here.
         """
         cli = merged.get("cursor", {}).get("cli", {})
         body = json.dumps(cli, indent=2) + "\n"

--- a/cli/templates/settings-user-cursor.json
+++ b/cli/templates/settings-user-cursor.json
@@ -16,5 +16,13 @@
     {"action": "allow", "host": "*.githubusercontent.com"},
     {"action": "allow", "host": "*.cursor.sh"},
     {"action": "allow", "host": "*.cursor.com"}
-  ]
+  ],
+  "cursor": {
+    "cli": {
+      "version": 1,
+      "network": {
+        "useHttp1ForAgent": true
+      }
+    }
+  }
 }

--- a/cli/test/agents/agents.bats
+++ b/cli/test/agents/agents.bats
@@ -67,7 +67,11 @@ setup() {
 	run sct_agent_host_config_paths cursor
 	assert_output --partial '$HOME/.cursor/rules/'
 	assert_output --partial '$HOME/.cursor/skills/'
+	assert_output --partial '$HOME/.cursor/commands/'
+	assert_output --partial '$HOME/.cursor/agents/'
+	assert_output --partial '$HOME/.cursor/hooks/'
 	assert_output --partial '$HOME/.cursor/AGENTS.md'
+	assert_output --partial '$HOME/.cursor/hooks.json'
 }
 
 @test "sct_agent_host_config_paths: unknown returns empty" {
@@ -98,6 +102,33 @@ setup() {
 	assert_success
 
 	[[ ! -d "$HOME/.claude" ]]
+}
+
+@test "ensure_host_agent_config_paths: creates cursor paths under HOME" {
+	export HOME="$BATS_TEST_TMPDIR/home"
+	mkdir -p "$HOME"
+
+	run ensure_host_agent_config_paths cursor
+	assert_success
+
+	[[ -d "$HOME/.cursor/rules" ]]
+	[[ -d "$HOME/.cursor/skills" ]]
+	[[ -d "$HOME/.cursor/commands" ]]
+	[[ -d "$HOME/.cursor/agents" ]]
+	[[ -d "$HOME/.cursor/hooks" ]]
+	[[ -f "$HOME/.cursor/AGENTS.md" ]]
+	[[ -f "$HOME/.cursor/hooks.json" ]]
+}
+
+@test "ensure_host_agent_config_paths: skips when SANDCAT_MOUNT_CURSOR_CONFIG=false" {
+	export HOME="$BATS_TEST_TMPDIR/home"
+	mkdir -p "$HOME"
+	export SANDCAT_MOUNT_CURSOR_CONFIG=false
+
+	run ensure_host_agent_config_paths cursor
+	assert_success
+
+	[[ ! -d "$HOME/.cursor" ]]
 }
 
 @test "ensure_host_agent_config_paths: no-op for unknown agent" {

--- a/cli/test/agents/agents.bats
+++ b/cli/test/agents/agents.bats
@@ -63,20 +63,28 @@ setup() {
 	assert_output --partial '$HOME/.claude/CLAUDE.md'
 }
 
+@test "sct_cursor_workspace_project_id: encodes /workspaces/<name>" {
+	run sct_cursor_workspace_project_id "foo-bar"
+	assert_output "workspaces-foo-bar"
+
+	run sct_cursor_workspace_project_id "project-sandbox"
+	assert_output "workspaces-project-sandbox"
+}
+
 @test "sct_agent_host_config_paths: cursor lists ~/.cursor entries" {
-	run sct_agent_host_config_paths cursor
+	run sct_agent_host_config_paths cursor "test-project"
 	assert_output --partial '$HOME/.cursor/rules/'
 	assert_output --partial '$HOME/.cursor/skills/'
 	assert_output --partial '$HOME/.cursor/commands/'
 	assert_output --partial '$HOME/.cursor/agents/'
 	assert_output --partial '$HOME/.cursor/hooks/'
-	assert_output --partial '$HOME/.cursor/projects/'
-	assert_output --partial '$HOME/.cursor/chats/'
-	assert_output --partial '$HOME/.cursor/plugins/'
-	assert_output --partial '$HOME/.cursor/subagents/'
+	assert_output --partial '$HOME/.cursor/projects/workspaces-test-project/'
 	assert_output --partial '$HOME/.cursor/AGENTS.md'
 	assert_output --partial '$HOME/.cursor/hooks.json'
 	assert_output --partial '$HOME/.cursor/mcp.json'
+	refute_output --partial '$HOME/.cursor/chats/'
+	refute_output --partial '$HOME/.cursor/plugins/'
+	refute_output --partial '$HOME/.cursor/subagents/'
 }
 
 @test "sct_agent_host_config_paths: unknown returns empty" {
@@ -113,7 +121,7 @@ setup() {
 	export HOME="$BATS_TEST_TMPDIR/home"
 	mkdir -p "$HOME"
 
-	run ensure_host_agent_config_paths cursor
+	run ensure_host_agent_config_paths cursor test
 	assert_success
 
 	[[ -d "$HOME/.cursor/rules" ]]
@@ -121,10 +129,7 @@ setup() {
 	[[ -d "$HOME/.cursor/commands" ]]
 	[[ -d "$HOME/.cursor/agents" ]]
 	[[ -d "$HOME/.cursor/hooks" ]]
-	[[ -d "$HOME/.cursor/projects" ]]
-	[[ -d "$HOME/.cursor/chats" ]]
-	[[ -d "$HOME/.cursor/plugins" ]]
-	[[ -d "$HOME/.cursor/subagents" ]]
+	[[ -d "$HOME/.cursor/projects/workspaces-test" ]]
 	[[ -f "$HOME/.cursor/AGENTS.md" ]]
 	[[ -f "$HOME/.cursor/hooks.json" ]]
 	[[ -f "$HOME/.cursor/mcp.json" ]]
@@ -137,7 +142,7 @@ setup() {
 	mkdir -p "$HOME/.cursor"
 	printf '%s\n' '{"hooks":{"stop":[{"command":"./hook.sh"}]}}' >"$HOME/.cursor/hooks.json"
 
-	run ensure_host_agent_config_paths cursor
+	run ensure_host_agent_config_paths cursor test
 	assert_success
 
 	assert_equal "$(<"$HOME/.cursor/hooks.json")" '{"hooks":{"stop":[{"command":"./hook.sh"}]}}'
@@ -148,7 +153,7 @@ setup() {
 	mkdir -p "$HOME"
 	export SANDCAT_MOUNT_CURSOR_CONFIG=false
 
-	run ensure_host_agent_config_paths cursor
+	run ensure_host_agent_config_paths cursor test
 	assert_success
 
 	[[ ! -d "$HOME/.cursor" ]]

--- a/cli/test/agents/agents.bats
+++ b/cli/test/agents/agents.bats
@@ -70,8 +70,13 @@ setup() {
 	assert_output --partial '$HOME/.cursor/commands/'
 	assert_output --partial '$HOME/.cursor/agents/'
 	assert_output --partial '$HOME/.cursor/hooks/'
+	assert_output --partial '$HOME/.cursor/projects/'
+	assert_output --partial '$HOME/.cursor/chats/'
+	assert_output --partial '$HOME/.cursor/plugins/'
+	assert_output --partial '$HOME/.cursor/subagents/'
 	assert_output --partial '$HOME/.cursor/AGENTS.md'
 	assert_output --partial '$HOME/.cursor/hooks.json'
+	assert_output --partial '$HOME/.cursor/mcp.json'
 }
 
 @test "sct_agent_host_config_paths: unknown returns empty" {
@@ -116,8 +121,26 @@ setup() {
 	[[ -d "$HOME/.cursor/commands" ]]
 	[[ -d "$HOME/.cursor/agents" ]]
 	[[ -d "$HOME/.cursor/hooks" ]]
+	[[ -d "$HOME/.cursor/projects" ]]
+	[[ -d "$HOME/.cursor/chats" ]]
+	[[ -d "$HOME/.cursor/plugins" ]]
+	[[ -d "$HOME/.cursor/subagents" ]]
 	[[ -f "$HOME/.cursor/AGENTS.md" ]]
 	[[ -f "$HOME/.cursor/hooks.json" ]]
+	[[ -f "$HOME/.cursor/mcp.json" ]]
+	assert_equal "$(<"$HOME/.cursor/hooks.json")" '{"hooks":{}}'
+	assert_equal "$(<"$HOME/.cursor/mcp.json")" '{"mcpServers":{}}'
+}
+
+@test "ensure_host_agent_config_paths: seeds empty JSON files but preserves existing content" {
+	export HOME="$BATS_TEST_TMPDIR/home"
+	mkdir -p "$HOME/.cursor"
+	printf '%s\n' '{"hooks":{"stop":[{"command":"./hook.sh"}]}}' >"$HOME/.cursor/hooks.json"
+
+	run ensure_host_agent_config_paths cursor
+	assert_success
+
+	assert_equal "$(<"$HOME/.cursor/hooks.json")" '{"hooks":{"stop":[{"command":"./hook.sh"}]}}'
 }
 
 @test "ensure_host_agent_config_paths: skips when SANDCAT_MOUNT_CURSOR_CONFIG=false" {
@@ -269,10 +292,10 @@ setup() {
 	assert_output --partial "hasCompletedOnboarding"
 }
 
-@test "sct_agent_user_init_block: cursor configures cli-config.json" {
+@test "sct_agent_user_init_block: cursor applies Sandcat cursor.cli fragment" {
 	run sct_agent_user_init_block cursor
-	assert_output --partial "cli-config.json"
-	assert_output --partial "useHttp1ForAgent"
+	assert_output --partial "cursor-cli-config.json"
+	assert_output --partial "Sandcat cursor.cli"
 }
 
 @test "sct_agent_user_init_block: unknown returns empty" {

--- a/cli/test/composefile/composefile.bats
+++ b/cli/test/composefile/composefile.bats
@@ -50,10 +50,10 @@ teardown() {
 }
 
 @test "add_cursor_config_volumes adds customization and state mounts" {
-	add_cursor_config_volumes "$COMPOSE_FILE"
+	add_cursor_config_volumes "$COMPOSE_FILE" true "test-project"
 
 	run yq '.services.agent.volumes | length' "$COMPOSE_FILE"
-	assert_output "13"
+	assert_output "10"
 
 	# shellcheck disable=SC2016
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/AGENTS.md:/home/vscode/.cursor/AGENTS.md:ro")' "$COMPOSE_FILE"
@@ -80,16 +80,7 @@ teardown() {
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/mcp.json:/home/vscode/.cursor/mcp.json:ro")' "$COMPOSE_FILE"
 
 	# shellcheck disable=SC2016
-	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/projects:/home/vscode/.cursor/projects")' "$COMPOSE_FILE"
-
-	# shellcheck disable=SC2016
-	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/chats:/home/vscode/.cursor/chats")' "$COMPOSE_FILE"
-
-	# shellcheck disable=SC2016
-	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/plugins:/home/vscode/.cursor/plugins")' "$COMPOSE_FILE"
-
-	# shellcheck disable=SC2016
-	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/subagents:/home/vscode/.cursor/subagents")' "$COMPOSE_FILE"
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/projects/workspaces-test-project:/home/vscode/.cursor/projects/workspaces-test-project")' "$COMPOSE_FILE"
 }
 
 
@@ -300,7 +291,7 @@ EOF
 	# shellcheck disable=SC2016
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/agents:/home/vscode/.cursor/agents:ro")' "$COMPOSE_FILE"
 	# shellcheck disable=SC2016
-	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/projects:/home/vscode/.cursor/projects")' "$COMPOSE_FILE"
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/projects/workspaces-test-project:/home/vscode/.cursor/projects/workspaces-test-project")' "$COMPOSE_FILE"
 	# No claude volumes leak through when agent=cursor.
 	run yq '.services.agent.volumes[] | select(test("\\.claude/"))' "$COMPOSE_FILE"
 	assert_output ""

--- a/cli/test/composefile/composefile.bats
+++ b/cli/test/composefile/composefile.bats
@@ -49,11 +49,11 @@ teardown() {
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.claude/commands:/home/vscode/.claude/commands:ro")' "$COMPOSE_FILE"
 }
 
-@test "add_cursor_config_volumes adds AGENTS.md, rules, skills, commands, hooks, and agents" {
+@test "add_cursor_config_volumes adds customization and state mounts" {
 	add_cursor_config_volumes "$COMPOSE_FILE"
 
 	run yq '.services.agent.volumes | length' "$COMPOSE_FILE"
-	assert_output "8"
+	assert_output "13"
 
 	# shellcheck disable=SC2016
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/AGENTS.md:/home/vscode/.cursor/AGENTS.md:ro")' "$COMPOSE_FILE"
@@ -75,6 +75,21 @@ teardown() {
 
 	# shellcheck disable=SC2016
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/agents:/home/vscode/.cursor/agents:ro")' "$COMPOSE_FILE"
+
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/mcp.json:/home/vscode/.cursor/mcp.json:ro")' "$COMPOSE_FILE"
+
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/projects:/home/vscode/.cursor/projects")' "$COMPOSE_FILE"
+
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/chats:/home/vscode/.cursor/chats")' "$COMPOSE_FILE"
+
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/plugins:/home/vscode/.cursor/plugins")' "$COMPOSE_FILE"
+
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/subagents:/home/vscode/.cursor/subagents")' "$COMPOSE_FILE"
 }
 
 
@@ -269,7 +284,7 @@ EOF
 # shellcheck disable=SC2016
 @test "customize_compose_file dispatches to add_cursor_config_volumes for cursor agent" {
 	# Dispatch smoke: representative cursor mounts; full list is covered by
-	# `add_cursor_config_volumes adds AGENTS.md, rules, skills, commands, hooks, and agents`.
+	# `add_cursor_config_volumes adds customization and state mounts`.
 	SETTINGS_FILE=".sandcat/settings.json"
 	mkdir -p "$BATS_TEST_TMPDIR/.sandcat"
 	touch "$BATS_TEST_TMPDIR/$SETTINGS_FILE"
@@ -284,6 +299,8 @@ EOF
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/hooks.json:/home/vscode/.cursor/hooks.json:ro")' "$COMPOSE_FILE"
 	# shellcheck disable=SC2016
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/agents:/home/vscode/.cursor/agents:ro")' "$COMPOSE_FILE"
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/projects:/home/vscode/.cursor/projects")' "$COMPOSE_FILE"
 	# No claude volumes leak through when agent=cursor.
 	run yq '.services.agent.volumes[] | select(test("\\.claude/"))' "$COMPOSE_FILE"
 	assert_output ""

--- a/cli/test/composefile/composefile.bats
+++ b/cli/test/composefile/composefile.bats
@@ -49,11 +49,11 @@ teardown() {
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.claude/commands:/home/vscode/.claude/commands:ro")' "$COMPOSE_FILE"
 }
 
-@test "add_cursor_config_volumes adds AGENTS.md, rules, and skills" {
+@test "add_cursor_config_volumes adds AGENTS.md, rules, skills, commands, hooks, and agents" {
 	add_cursor_config_volumes "$COMPOSE_FILE"
 
 	run yq '.services.agent.volumes | length' "$COMPOSE_FILE"
-	assert_output "4"
+	assert_output "8"
 
 	# shellcheck disable=SC2016
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/AGENTS.md:/home/vscode/.cursor/AGENTS.md:ro")' "$COMPOSE_FILE"
@@ -63,6 +63,18 @@ teardown() {
 
 	# shellcheck disable=SC2016
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/skills:/home/vscode/.cursor/skills:ro")' "$COMPOSE_FILE"
+
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/commands:/home/vscode/.cursor/commands:ro")' "$COMPOSE_FILE"
+
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/hooks.json:/home/vscode/.cursor/hooks.json:ro")' "$COMPOSE_FILE"
+
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/hooks:/home/vscode/.cursor/hooks:ro")' "$COMPOSE_FILE"
+
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/agents:/home/vscode/.cursor/agents:ro")' "$COMPOSE_FILE"
 }
 
 
@@ -256,16 +268,22 @@ EOF
 
 # shellcheck disable=SC2016
 @test "customize_compose_file dispatches to add_cursor_config_volumes for cursor agent" {
-	# We assert the dispatch (one Cursor-specific volume present) rather than
-	# re-listing every cursor mount; the per-volume contract is covered by
-	# `add_cursor_config_volumes adds AGENTS.md, rules, and skills`.
+	# Dispatch smoke: representative cursor mounts; full list is covered by
+	# `add_cursor_config_volumes adds AGENTS.md, rules, skills, commands, hooks, and agents`.
 	SETTINGS_FILE=".sandcat/settings.json"
 	mkdir -p "$BATS_TEST_TMPDIR/.sandcat"
 	touch "$BATS_TEST_TMPDIR/$SETTINGS_FILE"
 
 	customize_compose_file "$SETTINGS_FILE" "$COMPOSE_FILE" "cursor" "vscode" "test-project"
 
+	# shellcheck disable=SC2016
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/AGENTS.md:/home/vscode/.cursor/AGENTS.md:ro")' "$COMPOSE_FILE"
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/commands:/home/vscode/.cursor/commands:ro")' "$COMPOSE_FILE"
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/hooks.json:/home/vscode/.cursor/hooks.json:ro")' "$COMPOSE_FILE"
+	# shellcheck disable=SC2016
+	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.cursor/agents:/home/vscode/.cursor/agents:ro")' "$COMPOSE_FILE"
 	# No claude volumes leak through when agent=cursor.
 	run yq '.services.agent.volumes[] | select(test("\\.claude/"))' "$COMPOSE_FILE"
 	assert_output ""

--- a/cli/test/init/extensions.bats
+++ b/cli/test/init/extensions.bats
@@ -152,7 +152,7 @@ teardown() {
 
 	customize_agent_templates "$BATS_TEST_TMPDIR" "cursor"
 
-	run grep '"$HOME/.config/cursor/cli-config.json"' "$BATS_TEST_TMPDIR/sandcat/scripts/app-user-init.sh"
+	run grep 'cursor-cli-config.json' "$BATS_TEST_TMPDIR/sandcat/scripts/app-user-init.sh"
 	assert_success
 
 	run grep 'http2=true' "$BATS_TEST_TMPDIR/sandcat/compose-proxy.yml"

--- a/cli/test/init/init.bats
+++ b/cli/test/init/init.bats
@@ -181,7 +181,11 @@ teardown() {
 
 	[[ -d "$HOME/.cursor/rules" ]]
 	[[ -d "$HOME/.cursor/skills" ]]
+	[[ -d "$HOME/.cursor/commands" ]]
+	[[ -d "$HOME/.cursor/agents" ]]
+	[[ -d "$HOME/.cursor/hooks" ]]
 	[[ -f "$HOME/.cursor/AGENTS.md" ]]
+	[[ -f "$HOME/.cursor/hooks.json" ]]
 }
 
 @test "init skips host pre-creation when SANDCAT_MOUNT_CURSOR_CONFIG=false" {
@@ -196,6 +200,10 @@ teardown() {
 
 	[[ ! -d "$HOME/.cursor/rules" ]]
 	[[ ! -e "$HOME/.cursor/AGENTS.md" ]]
+	[[ ! -d "$HOME/.cursor/commands" ]]
+	[[ ! -d "$HOME/.cursor/agents" ]]
+	[[ ! -d "$HOME/.cursor/hooks" ]]
+	[[ ! -e "$HOME/.cursor/hooks.json" ]]
 }
 
 @test "init interactive flow (devcontainer mode)" {

--- a/cli/test/init/init.bats
+++ b/cli/test/init/init.bats
@@ -184,10 +184,7 @@ teardown() {
 	[[ -d "$HOME/.cursor/commands" ]]
 	[[ -d "$HOME/.cursor/agents" ]]
 	[[ -d "$HOME/.cursor/hooks" ]]
-	[[ -d "$HOME/.cursor/projects" ]]
-	[[ -d "$HOME/.cursor/chats" ]]
-	[[ -d "$HOME/.cursor/plugins" ]]
-	[[ -d "$HOME/.cursor/subagents" ]]
+	[[ -d "$HOME/.cursor/projects/workspaces-test" ]]
 	[[ -f "$HOME/.cursor/AGENTS.md" ]]
 	[[ -f "$HOME/.cursor/hooks.json" ]]
 	[[ -f "$HOME/.cursor/mcp.json" ]]
@@ -211,8 +208,6 @@ teardown() {
 	[[ ! -e "$HOME/.cursor/hooks.json" ]]
 	[[ ! -d "$HOME/.cursor/projects" ]]
 	[[ ! -d "$HOME/.cursor/chats" ]]
-	[[ ! -d "$HOME/.cursor/plugins" ]]
-	[[ ! -d "$HOME/.cursor/subagents" ]]
 	[[ ! -e "$HOME/.cursor/mcp.json" ]]
 }
 

--- a/cli/test/init/init.bats
+++ b/cli/test/init/init.bats
@@ -184,8 +184,13 @@ teardown() {
 	[[ -d "$HOME/.cursor/commands" ]]
 	[[ -d "$HOME/.cursor/agents" ]]
 	[[ -d "$HOME/.cursor/hooks" ]]
+	[[ -d "$HOME/.cursor/projects" ]]
+	[[ -d "$HOME/.cursor/chats" ]]
+	[[ -d "$HOME/.cursor/plugins" ]]
+	[[ -d "$HOME/.cursor/subagents" ]]
 	[[ -f "$HOME/.cursor/AGENTS.md" ]]
 	[[ -f "$HOME/.cursor/hooks.json" ]]
+	[[ -f "$HOME/.cursor/mcp.json" ]]
 }
 
 @test "init skips host pre-creation when SANDCAT_MOUNT_CURSOR_CONFIG=false" {
@@ -204,6 +209,11 @@ teardown() {
 	[[ ! -d "$HOME/.cursor/agents" ]]
 	[[ ! -d "$HOME/.cursor/hooks" ]]
 	[[ ! -e "$HOME/.cursor/hooks.json" ]]
+	[[ ! -d "$HOME/.cursor/projects" ]]
+	[[ ! -d "$HOME/.cursor/chats" ]]
+	[[ ! -d "$HOME/.cursor/plugins" ]]
+	[[ ! -d "$HOME/.cursor/subagents" ]]
+	[[ ! -e "$HOME/.cursor/mcp.json" ]]
 }
 
 @test "init interactive flow (devcontainer mode)" {

--- a/cli/test/init/regression.bats
+++ b/cli/test/init/regression.bats
@@ -270,38 +270,8 @@ assert_cursor_volumes() {
 		.services.agent.volumes[] |
 		select(
 			.type == \"bind\" and
-			.source == (env(HOME) + \"/.cursor/projects\") and
-			.target == \"/home/vscode/.cursor/projects\" and
-			(.read_only // false) == false
-		)
-	" "$compose_file"
-
-	HOME="$HOME" yq -e "
-		.services.agent.volumes[] |
-		select(
-			.type == \"bind\" and
-			.source == (env(HOME) + \"/.cursor/chats\") and
-			.target == \"/home/vscode/.cursor/chats\" and
-			(.read_only // false) == false
-		)
-	" "$compose_file"
-
-	HOME="$HOME" yq -e "
-		.services.agent.volumes[] |
-		select(
-			.type == \"bind\" and
-			.source == (env(HOME) + \"/.cursor/plugins\") and
-			.target == \"/home/vscode/.cursor/plugins\" and
-			(.read_only // false) == false
-		)
-	" "$compose_file"
-
-	HOME="$HOME" yq -e "
-		.services.agent.volumes[] |
-		select(
-			.type == \"bind\" and
-			.source == (env(HOME) + \"/.cursor/subagents\") and
-			.target == \"/home/vscode/.cursor/subagents\" and
+			.source == (env(HOME) + \"/.cursor/projects/workspaces-project-sandbox\") and
+			.target == \"/home/vscode/.cursor/projects/workspaces-project-sandbox\" and
 			(.read_only // false) == false
 		)
 	" "$compose_file"

--- a/cli/test/init/regression.bats
+++ b/cli/test/init/regression.bats
@@ -205,6 +205,56 @@ assert_cursor_volumes() {
 			.read_only == true
 		)
 	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/skills\") and
+			.target == \"/home/vscode/.cursor/skills\" and
+			.read_only == true
+		)
+	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/commands\") and
+			.target == \"/home/vscode/.cursor/commands\" and
+			.read_only == true
+		)
+	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/agents\") and
+			.target == \"/home/vscode/.cursor/agents\" and
+			.read_only == true
+		)
+	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/hooks\") and
+			.target == \"/home/vscode/.cursor/hooks\" and
+			.read_only == true
+		)
+	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/hooks.json\") and
+			.target == \"/home/vscode/.cursor/hooks.json\" and
+			.read_only == true
+		)
+	" "$compose_file"
 }
 
 assert_devcontainer_volume() {

--- a/cli/test/init/regression.bats
+++ b/cli/test/init/regression.bats
@@ -255,6 +255,56 @@ assert_cursor_volumes() {
 			.read_only == true
 		)
 	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/mcp.json\") and
+			.target == \"/home/vscode/.cursor/mcp.json\" and
+			.read_only == true
+		)
+	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/projects\") and
+			.target == \"/home/vscode/.cursor/projects\" and
+			(.read_only // false) == false
+		)
+	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/chats\") and
+			.target == \"/home/vscode/.cursor/chats\" and
+			(.read_only // false) == false
+		)
+	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/plugins\") and
+			.target == \"/home/vscode/.cursor/plugins\" and
+			(.read_only // false) == false
+		)
+	" "$compose_file"
+
+	HOME="$HOME" yq -e "
+		.services.agent.volumes[] |
+		select(
+			.type == \"bind\" and
+			.source == (env(HOME) + \"/.cursor/subagents\") and
+			.target == \"/home/vscode/.cursor/subagents\" and
+			(.read_only // false) == false
+		)
+	" "$compose_file"
 }
 
 assert_devcontainer_volume() {

--- a/cli/test/init/user_settings.bats
+++ b/cli/test/init/user_settings.bats
@@ -124,6 +124,8 @@ teardown() {
 	local settings="$HOME/.config/sandcat/settings.json"
 	yq -e '.network[] | select(.host == "*.cursor.sh")' "$settings"
 	yq -e '.network[] | select(.host == "*.cursor.com")' "$settings"
+	yq -e '.cursor.cli.network.useHttp1ForAgent == true' "$settings"
+	yq -e '.cursor.cli.version == 1' "$settings"
 }
 
 @test "create_user_settings skips when file already exists" {
@@ -161,4 +163,25 @@ EOF
 	yq -e '.secrets.CURSOR_API_KEY.hosts[] | select(. == "api2.cursor.sh")' "$settings"
 	yq -e '.secrets.CURSOR_API_KEY.hosts[] | select(. == "*.cursor.sh")' "$settings"
 	yq -e '.secrets.CURSOR_API_KEY.hosts[] | select(. == "*.cursor.com")' "$settings"
+	yq -e '.cursor.cli.network.useHttp1ForAgent == true' "$settings"
+}
+
+@test "ensure_cursor_user_settings_defaults preserves explicit cursor.cli overrides" {
+	mkdir -p "$HOME/.config/sandcat"
+	cat > "$HOME/.config/sandcat/settings.json" <<'EOF'
+{
+  "cursor": {
+    "cli": {
+      "network": {
+        "useHttp1ForAgent": false
+      }
+    }
+  }
+}
+EOF
+
+	ensure_cursor_user_settings_defaults
+
+	local settings="$HOME/.config/sandcat/settings.json"
+	yq -e '.cursor.cli.network.useHttp1ForAgent == false' "$settings"
 }

--- a/cli/test/mitmproxy/test_mitmproxy_addon.py
+++ b/cli/test/mitmproxy/test_mitmproxy_addon.py
@@ -1798,6 +1798,7 @@ class TestSettingsMerging:
         assert merged["env"] == {"A": "1"}
         assert merged["secrets"] == {}
         assert merged["network"] == [{"action": "allow", "host": "*"}]
+        assert merged["cursor"] == {"cli": {}}
         assert merged["op_service_account_token"] is None
         assert merged["proton_pass_token"] is None
 
@@ -1845,10 +1846,37 @@ class TestSettingsMerging:
             "env": {},
             "secrets": {},
             "network": [],
+            "cursor": {"cli": {}},
             "op_service_account_token": None,
             "dns_servers": None,
             "proton_pass_token": None,
         }
+
+    def test_cursor_cli_deep_merge_higher_precedence_wins(self):
+        layers = [
+            {"cursor": {"cli": {"version": 1, "network": {"useHttp1ForAgent": True}}}},
+            {"cursor": {"cli": {"network": {"useHttp1ForAgent": False}}}},
+        ]
+        merged = BaseAddon._merge_settings(layers)
+        assert merged["cursor"]["cli"]["version"] == 1
+        assert merged["cursor"]["cli"]["network"]["useHttp1ForAgent"] is False
+
+    def test_write_cursor_cli_config_from_merged_settings(self, tmp_path):
+        addon = BaseAddon()
+        merged = {
+            "cursor": {
+                "cli": {
+                    "version": 1,
+                    "network": {"useHttp1ForAgent": True},
+                }
+            }
+        }
+        config_path = tmp_path / "cursor-cli-config.json"
+        with patch(f"{_COMMON}.CURSOR_CLI_CONFIG_PATH", str(config_path)):
+            addon._write_cursor_cli_config(merged)
+        written = json.loads(config_path.read_text())
+        assert written["network"]["useHttp1ForAgent"] is True
+        assert written["version"] == 1
 
     def test_dns_servers_highest_precedence_wins(self):
         layers = [

--- a/cli/test/mitmproxy/test_mitmproxy_addon.py
+++ b/cli/test/mitmproxy/test_mitmproxy_addon.py
@@ -128,6 +128,16 @@ ADDONS = [
 # Helpers
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+def _patch_cursor_cli_config_path(tmp_path):
+    """load() writes cursor-cli-config.json; keep it off the real mitmproxy home."""
+    with patch(
+        f"{_COMMON}.CURSOR_CLI_CONFIG_PATH",
+        str(tmp_path / "cursor-cli-config.json"),
+    ):
+        yield
+
+
 def _make_flow(method="GET", host="example.com", url=None, headers=None, content=None):
     flow = MagicMock()
     flow.request = _Request(

--- a/cli/test/run/run.bats
+++ b/cli/test/run/run.bats
@@ -33,6 +33,14 @@ teardown() {
 }
 
 @test "warning when image is much newer than volume" {
+	# warn_stale_home_volume uses GNU date (-d flag) and silently skips the
+	# stale-volume check when it is unavailable (e.g. BSD date on macOS).
+	# Skip this test on those platforms so it only runs where the warning
+	# is actually emitted.
+	if ! date -d "2024-01-01T00:00:00Z" +%s &>/dev/null; then
+		skip "requires GNU date"
+	fi
+
 	stub docker \
 		"volume inspect myproject-sandbox_agent-home : :" \
 		"volume inspect --format {{.CreatedAt}} myproject-sandbox_agent-home : echo '2024-01-15T10:00:00Z'" \


### PR DESCRIPTION
## Summary

Align Sandcat devcontainers with Cursor CLI host configuration: mount shared customization from `~/.cursor/`, persist this sandbox's runtime state without leaking other workspaces, and manage Cursor CLI keys through Sandcat settings instead of bind-mounting `cli-config.json`.

- Mount additional Cursor host paths when `SANDCAT_MOUNT_CURSOR_CONFIG=true`: `commands/`, `hooks.json`, `hooks/`, `agents/`, and `mcp.json` (read-only), alongside existing `AGENTS.md`, `rules/`, and `skills/`
- Pre-create missing host bind sources on `sandcat init` (directories via `mkdir`, JSON files with minimal valid defaults) so Docker mounts files instead of root-owned empty directories
- Add Sandcat-controlled Cursor CLI config via `cursor.cli` in settings: mitmproxy merges settings layers, writes `/mitmproxy-config/cursor-cli-config.json`, and the agent deep-merges that fragment into `cli-config.json` in `agent-home` on startup (Sandcat keys win; Cursor-managed keys persist in the volume). Default `cursor.cli.network.useHttp1ForAgent: true` for mitmproxy stability
- Scope runtime state to the current workspace only: mount `~/.cursor/projects/workspaces-<project-name>/` read-write; keep `chats/`, `plugins/`, and `subagents/` in `agent-home` so other workspaces' Cursor data is not exposed
- Document optional volume mount customization (all-or-nothing init flags, per-path compose editing, Claude vs Cursor path tables, isolation notes)

## Test plan

- [ ] `cd cli && bats test/agents/agents.bats test/composefile/composefile.bats test/init/init.bats test/init/regression.bats test/init/user_settings.bats`
- [ ] `cd cli && pytest test/mitmproxy/test_mitmproxy_addon.py -k cursor_cli`
- [ ] `sandcat init --agent cursor --name myproject` and verify compose mounts only `projects/workspaces-myproject/`
- [ ] Rebuild devcontainer; confirm host `~/.cursor/rules/` etc. appear read-only in the agent
- [ ] Confirm `cli-config.json` in agent-home receives `useHttp1ForAgent` from Sandcat settings without a host bind mount
- [ ] Confirm agent cannot list other workspaces under `~/.cursor/projects/` or access host `chats/`, `plugins/`, `subagents/`