### PR TITLE
Give wg-client healthcheck a start_period for slow cold starts

### DIFF
--- a/cli/templates/devcontainer/sandcat/compose-proxy.yml
+++ b/cli/templates/devcontainer/sandcat/compose-proxy.yml
@@ -40,6 +40,15 @@ services:
       interval: 2s
       timeout: 2s
       retries: 15
+      # Without a start_period, retries*interval (~30s) is the whole window to
+      # finish init and touch /tmp/wg-ready. On a cold Docker VM the init's many
+      # forked steps (jq, wg, ip, iptables, dnsmasq, ss) run slowly and can
+      # exceed 30s, so early failures exhaust the retries and the container is
+      # wrongly marked unhealthy — aborting the run with "dependency wg-client
+      # failed to start ... is unhealthy". Failures during the start_period
+      # don't count; a single success ends it immediately, so a healthy start
+      # is still detected without delay.
+      start_period: 120s
 
   mitmproxy:
     image: mitmproxy/mitmproxy:latest


### PR DESCRIPTION
## Problem

`sandcat run` intermittently aborts on cold/first runs with:

```
Container <project>-wg-client-1 Error dependency wg-client failed to start
dependency failed to start: container <project>-wg-client-1 is unhealthy
```

The wg-client healthcheck has no `start_period`, so its entire window to finish init and touch `/tmp/wg-ready` is `retries:15 × interval:2s ≈ 30s`. On a cold Docker VM, wg-client's many forked init steps (jq, wg, ip, ~15× iptables, dnsmasq, ss) run slowly and can exceed 30s, exhausting the retries → the container is marked unhealthy → the run aborts. Warm runs finish init in ~3s (large margin), which is why this only bites on cold starts and is hard to reproduce.

## Reproduction / verification

Delaying readiness past the ~30s window (a `sleep` before `touch /tmp/wg-ready`, rebuilt image) reproduces the exact abort (`rc=1`). Adding `start_period` to the same setup makes it pass (`rc=0`), waiting through the slow start and then reporting healthy.

## Fix

Add `start_period: 120s` to the wg-client healthcheck, mirroring the `mitmproxy` healthcheck right below it (which already carries `start_period: 90s` for the same class of problem). Failures during the start period don't count toward retries, and a single success ends it immediately — so a healthy start is still detected without any added delay, while a slow cold start is no longer killed at 30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)