### PR TITLE
fix(cli): emit customizations.jetbrains when --ide jetbrains

### DIFF
--- a/cli/lib/devcontainer.bash
+++ b/cli/lib/devcontainer.bash
@@ -5,21 +5,67 @@ source "$SCT_LIBDIR/stacks.bash"
 # shellcheck source=agents.bash
 source "$SCT_LIBDIR/agents.bash"
 
-# Replaces __PROJECT_NAME__ placeholder with the actual project name in devcontainer.json.
+# Replaces __PROJECT_NAME__ placeholder with the actual project name and
+# selects the IDE-specific customizations block in devcontainer.json.
 #
 # Uses `sed` because `yq` does not support JSONC
 # Args:
 #   $1 - Path to the devcontainer.json file
 #   $2 - Project name to substitute
+#   $3 - IDE name: vscode | jetbrains | none (defaults to vscode)
 customize_devcontainer_json() {
 	local devcontainer_json=$1
 	local project_name=$2
+	local ide=${3:-vscode}
 
 	# Use sed in a way that works on both BSD (macOS) and GNU (Linux)
 	# Escape sed metacharacters in project_name (& and \ have special meaning)
 	local escaped_name
 	escaped_name=$(printf '%s' "$project_name" | sed 's/[&\\/]/\\&/g')
 	sed -i.bak "s/__PROJECT_NAME__/${escaped_name}/g" "$devcontainer_json" && rm -f "${devcontainer_json}.bak"
+
+	apply_ide_customizations "$devcontainer_json" "$ide"
+}
+
+# Rewrites the customizations block based on the selected IDE.
+#
+# The template wraps the vscode block with marker comment lines. Behavior:
+#   - vscode:    strip marker lines, keep block as-is
+#   - jetbrains: replace the vscode block with a JetBrains block
+#   - none:      drop the entire customizations block
+#
+# Args:
+#   $1 - Path to the devcontainer.json file
+#   $2 - IDE name: vscode | jetbrains | none
+apply_ide_customizations() {
+	local file=$1
+	local ide=$2
+
+	local tmpfile="${file}.tmp"
+	local in_block=0
+	local line
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		case "$line" in
+			*"__CUSTOMIZATIONS_START__"*)
+				in_block=1
+				if [[ "$ide" == "jetbrains" ]]; then
+					# JetBrains Gateway / IDE Services reads customizations.jetbrains.
+					# `backend` selects which JetBrains product opens the project;
+					# IntelliJ is a safe default and users can edit it per project.
+					printf '\t"customizations": {\n\t\t"jetbrains": {\n\t\t\t"backend": "IntelliJ",\n\t\t\t"plugins": [],\n\t\t\t"settings": {}\n\t\t}\n\t}\n'
+				fi
+				continue
+				;;
+			*"__CUSTOMIZATIONS_END__"*)
+				in_block=0
+				continue
+				;;
+		esac
+		if [[ $in_block -eq 0 || "$ide" == "vscode" ]]; then
+			printf '%s\n' "$line"
+		fi
+	done < "$file" > "$tmpfile"
+	mv "$tmpfile" "$file"
 }
 
 # Inserts RUN mise lines into the Dockerfile for selected stacks.

--- a/cli/libexec/init/devcontainer
+++ b/cli/libexec/init/devcontainer
@@ -116,7 +116,7 @@ devcontainer() {
 	customize_compose_file "$rel_settings_file" "$compose_file" "$agent" "$ide" "$project_name"
 	set_project_name "$compose_file" "$project_name"
 
-	customize_devcontainer_json "$devcontainer_dir/devcontainer.json" "$project_name"
+	customize_devcontainer_json "$devcontainer_dir/devcontainer.json" "$project_name" "$ide"
 
 	echo "Devcontainer dir created at ${devcontainer_dir#"$project_path"/}" | info
 }

--- a/cli/templates/devcontainer/devcontainer.json
+++ b/cli/templates/devcontainer/devcontainer.json
@@ -25,6 +25,7 @@
 		"GPG_AGENT_INFO": "",
 		"GIT_ASKPASS": ""
 	},
+	// __CUSTOMIZATIONS_START__
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -49,4 +50,5 @@
 			}
 		}
 	}
+	// __CUSTOMIZATIONS_END__
 }

--- a/cli/test/init/devcontainer.bats
+++ b/cli/test/init/devcontainer.bats
@@ -54,3 +54,62 @@ teardown() {
 	run grep '"overrideCommand": false' "$DEVCONTAINER_JSON"
 	assert_success
 }
+
+@test "customize_devcontainer_json keeps customizations.vscode when ide is vscode" {
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project" "vscode"
+
+	run grep '"vscode":' "$DEVCONTAINER_JSON"
+	assert_success
+	refute_output --partial '"jetbrains"'
+}
+
+@test "customize_devcontainer_json defaults to vscode when ide is omitted" {
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project"
+
+	run grep '"vscode":' "$DEVCONTAINER_JSON"
+	assert_success
+}
+
+@test "customize_devcontainer_json emits customizations.jetbrains when ide is jetbrains" {
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project" "jetbrains"
+
+	run grep '"jetbrains":' "$DEVCONTAINER_JSON"
+	assert_success
+	run grep '"backend": "IntelliJ"' "$DEVCONTAINER_JSON"
+	assert_success
+}
+
+@test "customize_devcontainer_json omits vscode block when ide is jetbrains" {
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project" "jetbrains"
+
+	run grep -c '"vscode":' "$DEVCONTAINER_JSON"
+	assert_output "0"
+}
+
+@test "customize_devcontainer_json drops customizations block when ide is none" {
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project" "none"
+
+	run grep -c '"customizations":' "$DEVCONTAINER_JSON"
+	assert_output "0"
+}
+
+@test "customize_devcontainer_json strips __CUSTOMIZATIONS markers for vscode" {
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project" "vscode"
+
+	run grep -c '__CUSTOMIZATIONS_' "$DEVCONTAINER_JSON"
+	assert_output "0"
+}
+
+@test "customize_devcontainer_json strips __CUSTOMIZATIONS markers for jetbrains" {
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project" "jetbrains"
+
+	run grep -c '__CUSTOMIZATIONS_' "$DEVCONTAINER_JSON"
+	assert_output "0"
+}
+
+@test "customize_devcontainer_json strips __CUSTOMIZATIONS markers for none" {
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project" "none"
+
+	run grep -c '__CUSTOMIZATIONS_' "$DEVCONTAINER_JSON"
+	assert_output "0"
+}


### PR DESCRIPTION
Closes #76

## Summary

- Thread the IDE selection from `sandcat init` through devcontainer.json generation so the `customizations` block matches the chosen IDE.
- For `--ide jetbrains`: emit `customizations.jetbrains` with `backend: "IntelliJ"` (and empty `plugins`/`settings` for the user to populate).
- For `--ide vscode`: unchanged behavior.
- For `--ide none`: drop the `customizations` block entirely.

## Test plan

- [x] 8 new bats tests in `test/init/devcontainer.bats` cover vscode/jetbrains/none paths and marker stripping.
- [x] Full `cli/run-tests.bash` suite passes (74/74).
- [x] End-to-end: `sandcat init --ide jetbrains` on a fresh Scala project → `customizations.jetbrains` present, no `vscode` key.
- [x] End-to-end: `sandcat init --ide vscode` → existing block preserved with agent extension, stack extensions, and settings intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)