### PR TITLE
fix(cli): set overrideCommand:false so app-init.sh runs in JetBrains

### DIFF
--- a/cli/templates/devcontainer/devcontainer.json
+++ b/cli/templates/devcontainer/devcontainer.json
@@ -3,6 +3,14 @@
 	"dockerComposeFile": "compose-all.yml",
 	"service": "agent",
 	"workspaceFolder": "/workspaces/__PROJECT_NAME__",
+	// Preserve the compose `command` so the container's ENTRYPOINT
+	// (app-init.sh) runs on start — it installs the mitmproxy CA,
+	// adopts wg-client's resolv.conf, loads sandcat.env, and drops
+	// to the vscode user. Without this, JetBrains Gateway silently
+	// overrides the command and skips app-init.sh, bypassing
+	// sandcat's security boundary. Matches the Dev Containers spec
+	// default for dockerComposeFile scenarios.
+	"overrideCommand": false,
 	// Remove credential sockets that VS Code forwards into the container
 	// (SSH agent, git credential helper).  Clearing env vars alone only
 	// hides the paths — the socket files in /tmp can still be discovered

--- a/cli/test/init/devcontainer.bats
+++ b/cli/test/init/devcontainer.bats
@@ -46,3 +46,11 @@ teardown() {
 	run grep '__STACK_EXTENSIONS__' "$DEVCONTAINER_JSON"
 	assert_success
 }
+
+@test "devcontainer.json template sets overrideCommand to false" {
+	# Required so the container's ENTRYPOINT (app-init.sh) runs on start —
+	# JetBrains Gateway historically defaults overrideCommand to true for
+	# compose scenarios, bypassing app-init.sh and sandcat's security setup.
+	run grep '"overrideCommand": false' "$DEVCONTAINER_JSON"
+	assert_success
+}


### PR DESCRIPTION
Closes #68

## Summary

Add `"overrideCommand": false` to the generated `devcontainer.json`. Per the Dev Containers spec this is the default for `dockerComposeFile` scenarios, but JetBrains Gateway historically defaults it to `true` ([IJPL-65923](https://youtrack.jetbrains.com/issue/IJPL-65923), [IJPL-65922](https://youtrack.jetbrains.com/issue/IJPL-65922)), which prevents the container's ENTRYPOINT (`app-init.sh`) from setting up the mitmproxy CA, `resolv.conf` override, `sandcat.env`, and git config — silently bypassing sandcat's security boundary.

Setting the value explicitly makes behavior deterministic across implementations. For VS Code this is a no-op (matches spec default).

## Test plan

- [x] New bats test in `test/init/devcontainer.bats` asserts the field is present in the template.
- [x] Full `cli/run-tests.bash` suite passes (67/67).
- Please verify on the JetBrains Gateway side that `app-init.sh` now runs on container start — I don't have Gateway available locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)