### PR TITLE
feat(cli): install JetBrains stack plugins via customizations.jetbrains

### DIFF
--- a/cli/lib/devcontainer.bash
+++ b/cli/lib/devcontainer.bash
@@ -105,6 +105,58 @@ customize_dockerfile() {
 	mv "$tmpfile" "$dockerfile"
 }
 
+# Adds JetBrains Marketplace plugins for selected stacks to devcontainer.json.
+# Replaces the empty `"plugins": []` inside the JetBrains customizations
+# block that apply_ide_customizations emits. Symmetric counterpart to
+# customize_devcontainer_extensions() for the VS Code path.
+#
+# Silently no-ops when no stack contributes a JetBrains plugin (e.g. stacks
+# where language support is bundled in the IDE) — the empty array stays.
+#
+# Args:
+#   $1 - Path to the devcontainer.json file
+#   $@ - Stack names (remaining args)
+customize_devcontainer_plugins() {
+	local devcontainer_json=$1
+	shift
+
+	local plugin_ids=()
+	local stack plugin
+	for stack in "$@"; do
+		plugin=$(stack_jetbrains_plugin "$stack")
+		if [[ -n "$plugin" ]]; then
+			plugin_ids+=("$plugin")
+		fi
+	done
+
+	if [[ ${#plugin_ids[@]} -eq 0 ]]; then
+		return 0
+	fi
+
+	# Build the JSON array literal: "id1", "id2", "id3"
+	local joined=""
+	local id
+	for id in "${plugin_ids[@]}"; do
+		if [[ -n "$joined" ]]; then
+			joined+=", "
+		fi
+		joined+="\"${id}\""
+	done
+
+	# Rewrite `"plugins": []` in place. The literal is uniquely emitted by
+	# apply_ide_customizations, so a simple line rewrite is safe here.
+	local tmpfile="${devcontainer_json}.tmp"
+	local line
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" == *'"plugins": []'* ]]; then
+			printf '%s\n' "${line//\"plugins\": \[\]/\"plugins\": [${joined}]}"
+		else
+			printf '%s\n' "$line"
+		fi
+	done < "$devcontainer_json" > "$tmpfile"
+	mv "$tmpfile" "$devcontainer_json"
+}
+
 # Adds VS Code extensions for selected stacks to devcontainer.json.
 # Replaces the // __STACK_EXTENSIONS__ placeholder line.
 # Args:

--- a/cli/lib/devcontainer.bash
+++ b/cli/lib/devcontainer.bash
@@ -72,6 +72,58 @@ apply_ide_customizations() {
 	mv "$tmpfile" "$file"
 }
 
+# Adds JetBrains Marketplace plugins for selected stacks to devcontainer.json.
+# Replaces the empty `"plugins": []` inside the JetBrains customizations
+# block that apply_ide_customizations emits. Symmetric counterpart to
+# customize_devcontainer_extensions() for the VS Code path.
+#
+# Silently no-ops when no stack contributes a JetBrains plugin (e.g. stacks
+# where language support is bundled in the IDE) — the empty array stays.
+#
+# Args:
+#   $1 - Path to the devcontainer.json file
+#   $@ - Stack names (remaining args)
+customize_devcontainer_plugins() {
+	local devcontainer_json=$1
+	shift
+
+	local plugin_ids=()
+	local stack plugin
+	for stack in "$@"; do
+		plugin=$(stack_jetbrains_plugin "$stack")
+		if [[ -n "$plugin" ]]; then
+			plugin_ids+=("$plugin")
+		fi
+	done
+
+	if [[ ${#plugin_ids[@]} -eq 0 ]]; then
+		return 0
+	fi
+
+	# Build the JSON array literal: "id1", "id2", "id3"
+	local joined=""
+	local id
+	for id in "${plugin_ids[@]}"; do
+		if [[ -n "$joined" ]]; then
+			joined+=", "
+		fi
+		joined+="\"${id}\""
+	done
+
+	# Rewrite `"plugins": []` in place. The literal is uniquely emitted by
+	# apply_ide_customizations, so a simple line rewrite is safe here.
+	local tmpfile="${devcontainer_json}.tmp"
+	local line
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" == *'"plugins": []'* ]]; then
+			printf '%s\n' "${line//\"plugins\": \[\]/\"plugins\": [${joined}]}"
+		else
+			printf '%s\n' "$line"
+		fi
+	done < "$devcontainer_json" > "$tmpfile"
+	mv "$tmpfile" "$devcontainer_json"
+}
+
 # Adds VS Code extensions for selected stacks to devcontainer.json.
 # Replaces the // __STACK_EXTENSIONS__ placeholder line.
 # Args:

--- a/cli/lib/stacks.bash
+++ b/cli/lib/stacks.bash
@@ -34,6 +34,37 @@ stack_extension() {
 	esac
 }
 
+# Returns the JetBrains Marketplace plugin ID for a stack (empty if none).
+# Symmetric to stack_extension() for the JetBrains devcontainer path.
+# Gateway installs entries listed here into the backend IDE at start-up.
+#
+# Notes on editions and bundling:
+#   - node/java: language support is bundled in IntelliJ IDEA (Community
+#     and Ultimate). No plugin needed.
+#   - python: PythonCore is the free plugin that ships with PyCharm
+#     Community and works in IntelliJ IDEA Community as well.
+#   - go/ruby/nodejs-advanced: JetBrains gates these behind Ultimate.
+#     The plugin IDs below install correctly only when the backend is
+#     an Ultimate build (or the language-specific IDE like GoLand,
+#     RubyMine, WebStorm). On Community backends Gateway silently skips
+#     them.
+#   - dotnet: primary JetBrains IDE is Rider (standalone); IntelliJ does
+#     not have a first-party .NET plugin, so we emit nothing.
+#   - rust: JetBrains split Rust into standalone RustRover; the old
+#     intellij-rust plugin was discontinued. Emit nothing until Rust
+#     support is available as a first-party plugin again.
+#   - zig: community-maintained ZigBrains plugin.
+stack_jetbrains_plugin() {
+	case $1 in
+		python) echo "PythonCore" ;;
+		scala)  echo "org.intellij.scala" ;;
+		go)     echo "org.jetbrains.plugins.go" ;;
+		ruby)   echo "org.jetbrains.plugins.ruby" ;;
+		zig)    echo "com.falsepattern.zigbrains" ;;
+		*)      echo "" ;;
+	esac
+}
+
 # Returns space-separated dependency stack names (empty if none).
 stack_deps() {
 	case $1 in

--- a/cli/lib/stacks.bash
+++ b/cli/lib/stacks.bash
@@ -60,6 +60,37 @@ stack_env_entries() {
 	esac
 }
 
+# Returns the JetBrains Marketplace plugin ID for a stack (empty if none).
+# Symmetric to stack_extension() for the JetBrains devcontainer path.
+# Gateway installs entries listed here into the backend IDE at start-up.
+#
+# Notes on editions and bundling:
+#   - node/java: language support is bundled in IntelliJ IDEA (Community
+#     and Ultimate). No plugin needed.
+#   - python: PythonCore is the free plugin that ships with PyCharm
+#     Community and works in IntelliJ IDEA Community as well.
+#   - go/ruby/nodejs-advanced: JetBrains gates these behind Ultimate.
+#     The plugin IDs below install correctly only when the backend is
+#     an Ultimate build (or the language-specific IDE like GoLand,
+#     RubyMine, WebStorm). On Community backends Gateway silently skips
+#     them.
+#   - dotnet: primary JetBrains IDE is Rider (standalone); IntelliJ does
+#     not have a first-party .NET plugin, so we emit nothing.
+#   - rust: JetBrains split Rust into standalone RustRover; the old
+#     intellij-rust plugin was discontinued. Emit nothing until Rust
+#     support is available as a first-party plugin again.
+#   - zig: community-maintained ZigBrains plugin.
+stack_jetbrains_plugin() {
+	case $1 in
+		python) echo "PythonCore" ;;
+		scala)  echo "org.intellij.scala" ;;
+		go)     echo "org.jetbrains.plugins.go" ;;
+		ruby)   echo "org.jetbrains.plugins.ruby" ;;
+		zig)    echo "com.falsepattern.zigbrains" ;;
+		*)      echo "" ;;
+	esac
+}
+
 # Returns space-separated dependency stack names (empty if none).
 stack_deps() {
 	case $1 in

--- a/cli/libexec/init/devcontainer
+++ b/cli/libexec/init/devcontainer
@@ -118,6 +118,14 @@ devcontainer() {
 
 	customize_devcontainer_json "$devcontainer_dir/devcontainer.json" "$project_name" "$ide"
 
+	# JetBrains plugins must be seeded after customize_devcontainer_json emits
+	# the customizations.jetbrains block. No-op for other IDEs.
+	if [[ "$ide" == "jetbrains" && -n "$stacks" ]]; then
+		local stacks_arr_jb=()
+		read -ra stacks_arr_jb <<< "$stacks"
+		customize_devcontainer_plugins "$devcontainer_dir/devcontainer.json" "${stacks_arr_jb[@]}"
+	fi
+
 	echo "Devcontainer dir created at ${devcontainer_dir#"$project_path"/}" | info
 }
 

--- a/cli/libexec/init/devcontainer
+++ b/cli/libexec/init/devcontainer
@@ -124,6 +124,14 @@ devcontainer() {
 
 	customize_devcontainer_json "$devcontainer_dir/devcontainer.json" "$project_name" "$ide"
 
+	# JetBrains plugins must be seeded after customize_devcontainer_json emits
+	# the customizations.jetbrains block. No-op for other IDEs.
+	if [[ "$ide" == "jetbrains" && -n "$stacks" ]]; then
+		local stacks_arr_jb=()
+		read -ra stacks_arr_jb <<< "$stacks"
+		customize_devcontainer_plugins "$devcontainer_dir/devcontainer.json" "${stacks_arr_jb[@]}"
+	fi
+
 	echo "Devcontainer dir created at ${devcontainer_dir#"$project_path"/}" | info
 }
 

--- a/cli/test/init/jetbrains_plugins.bats
+++ b/cli/test/init/jetbrains_plugins.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
+
+setup() {
+	load test_helper
+	# shellcheck source=../../lib/devcontainer.bash
+	source "$SCT_LIBDIR/devcontainer.bash"
+
+	DEVCONTAINER_JSON="$BATS_TEST_TMPDIR/devcontainer.json"
+	cp "$SCT_TEMPLATEDIR/devcontainer/devcontainer.json" "$DEVCONTAINER_JSON"
+
+	# Emit the JetBrains customizations block so plugins tests have
+	# `"plugins": []` to rewrite. This mirrors the production order:
+	# customize_devcontainer_json runs before customize_devcontainer_plugins.
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project" "jetbrains"
+}
+
+teardown() {
+	unstub_all
+}
+
+@test "customize_devcontainer_plugins inserts a plugin for a stack that has one" {
+	customize_devcontainer_plugins "$DEVCONTAINER_JSON" "scala"
+
+	run grep '"plugins": \["org.intellij.scala"\]' "$DEVCONTAINER_JSON"
+	assert_success
+}
+
+@test "customize_devcontainer_plugins joins multiple plugin ids" {
+	customize_devcontainer_plugins "$DEVCONTAINER_JSON" "scala" "python" "go"
+
+	run grep '"plugins": \["org.intellij.scala", "PythonCore", "org.jetbrains.plugins.go"\]' "$DEVCONTAINER_JSON"
+	assert_success
+}
+
+@test "customize_devcontainer_plugins keeps empty array when no stack contributes a plugin" {
+	# java is bundled — stack_jetbrains_plugin returns empty for it.
+	customize_devcontainer_plugins "$DEVCONTAINER_JSON" "java"
+
+	run grep '"plugins": \[\]' "$DEVCONTAINER_JSON"
+	assert_success
+}
+
+@test "customize_devcontainer_plugins keeps empty array when called with no stacks" {
+	customize_devcontainer_plugins "$DEVCONTAINER_JSON"
+
+	run grep '"plugins": \[\]' "$DEVCONTAINER_JSON"
+	assert_success
+}
+
+@test "customize_devcontainer_plugins skips stacks whose plugin is bundled" {
+	# Mixing java (bundled → skipped) and scala (has plugin) should
+	# produce only the scala plugin.
+	customize_devcontainer_plugins "$DEVCONTAINER_JSON" "java" "scala"
+
+	run grep '"plugins": \["org.intellij.scala"\]' "$DEVCONTAINER_JSON"
+	assert_success
+}
+
+@test "customize_devcontainer_plugins does nothing when called on a vscode devcontainer.json" {
+	# Reset to a fresh vscode-style file (no jetbrains block, no `"plugins": []`).
+	cp "$SCT_TEMPLATEDIR/devcontainer/devcontainer.json" "$DEVCONTAINER_JSON"
+	customize_devcontainer_json "$DEVCONTAINER_JSON" "my-project" "vscode"
+
+	customize_devcontainer_plugins "$DEVCONTAINER_JSON" "scala"
+
+	# vscode block has "extensions": [...] but no "plugins": [] to rewrite.
+	# The function should have been a no-op.
+	run grep 'org.intellij.scala' "$DEVCONTAINER_JSON"
+	assert_failure
+}


### PR DESCRIPTION
## Summary

Symmetric counterpart for the JetBrains devcontainer path to how VS Code stacks already work: `sandcat init --ide jetbrains --stacks scala` now seeds `customizations.jetbrains.plugins` with `["org.intellij.scala"]`, so Gateway auto-installs the plugin into the backend IDE at first start. Today the array is emitted empty regardless of stack selection.

## Motivation

Existing `stack_extension()` in `cli/lib/stacks.bash` maps `scala → scalameta.metals` (etc.) into `customizations.vscode.extensions` for the VS Code path. Nothing analogous exists for JetBrains — users need to open the plugin marketplace inside Gateway and install manually every time. The JetBrains devcontainer spec supports `customizations.jetbrains.plugins` natively (Gateway parses this block and installs listed marketplace IDs at backend start-up); we already emit the surrounding block via `apply_ide_customizations` — just with `"plugins": []`.

## Changes

- **`cli/lib/stacks.bash`** — new `stack_jetbrains_plugin()` lookup, mirroring `stack_extension()`. Only maps stacks with first-party or well-established plugins:
  - `python → PythonCore`
  - `scala → org.intellij.scala`
  - `go → org.jetbrains.plugins.go` *(Ultimate/GoLand only)*
  - `ruby → org.jetbrains.plugins.ruby` *(Ultimate/RubyMine only)*
  - `zig → com.falsepattern.zigbrains` *(community)*
  - `node`, `java` → empty (language support bundled in IntelliJ)
  - `rust`, `dotnet` → empty (RustRover / Rider are standalone IDEs; no first-party IntelliJ plugin)
  See the function docstring for edition caveats.

- **`cli/lib/devcontainer.bash`** — new `customize_devcontainer_plugins()`, symmetric to the existing `customize_devcontainer_extensions()`. Rewrites the literal `"plugins": []` emitted by `apply_ide_customizations` in place. No-op if no stack contributes a plugin.

- **`cli/libexec/init/devcontainer`** — invoke `customize_devcontainer_plugins` **after** `customize_devcontainer_json` (so the JetBrains block exists) and only when `--ide jetbrains` with non-empty `--stacks`.

- **`cli/test/init/jetbrains_plugins.bats`** — 6 new tests covering: single plugin, multiple plugins, bundled-only stack (no rewrite), no stacks (no rewrite), mixed bundled+non-bundled, no-op on vscode devcontainer.json.

## Example

```console
$ sandcat init --agent claude --ide jetbrains --stacks scala,python --name demo
```

Generates in `.devcontainer/devcontainer.json`:

```jsonc
"customizations": {
    "jetbrains": {
        "backend": "IntelliJ",
        "plugins": ["org.intellij.scala", "PythonCore"],
        "settings": {}
    }
}
```

Gateway installs both plugins into the IntelliJ backend on first start. Downloads go to `plugins.jetbrains.com` / `downloads.marketplace.jetbrains.com`, already in the JetBrains row of the default network allowlist (README §Network access rules).

## Test plan

- [x] `bats cli/test/init/` — 81 tests pass locally (6 new + 75 existing)
- [ ] End-to-end: `sandcat init --ide jetbrains --stacks scala` on a fresh project, open in JetBrains Gateway, verify the Scala plugin appears installed in the backend's Plugins UI at first launch (not yet run — requires Gateway + Marketplace access)

## Non-goals / notes for reviewer

- **No explicit `--jetbrains-plugins` flag.** Users who want additional plugins beyond stack defaults edit `.devcontainer/devcontainer.json` directly. Same escape hatch as for the vscode `extensions` array today.
- **No plugin version pinning.** Gateway resolves "latest compatible" for the backend IDE version. Matches VS Code side (extension versions also unpinned).
- **Ultimate-only plugins on Community backends silently skip.** Gateway logs a warning but does not fail startup — matches Marketplace's own install semantics. Documented in the `stack_jetbrains_plugin()` docstring.
- **`rust` and `dotnet` intentionally return empty.** Both moved to standalone JetBrains IDEs (RustRover, Rider) with no maintained IntelliJ plugin equivalent. Happy to re-add if there's a preferred community plugin to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)