### PR TITLE
feat(cli): shared JVM dependency-cache volumes + `sandcat cache` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ flags today.
 | Cursor    | `SANDCAT_MOUNT_CURSOR_CONFIG` | `true`                                  |
 | Any       | `SANDCAT_MOUNT_GIT_READONLY`  | `false` (commented in compose)          |
 | JetBrains | `SANDCAT_MOUNT_IDEA_READONLY` | `false` (active when `--ide jetbrains`) |
+| Any       | `SANDCAT_MOUNT_SHARED_CACHE`  | `true` — see [Shared dependency caches](#shared-dependency-caches) |
 
 When an agent mount flag is `false`, Sandcat lists every path as a foot comment
 on the first volume entry — copy the lines you want into the active `volumes:`
@@ -248,6 +249,87 @@ this sandbox persist under host `projects/<workspace-id>/` only
 `plugins/`, and `subagents/`, are not mounted. To keep a sandcat project fully
 isolated from host agent state, set `SANDCAT_MOUNT_<AGENT>_CONFIG=false` and
 rely on repo-local config plus the `agent-home` volume inside the container.
+
+#### Shared dependency caches
+
+For stacks that download a lot of common dependencies, sandcat mounts a set
+of **host-scoped named volumes** so `cats-effect`, `spring-boot`, etc.
+downloaded in one project are instantly available in every other project on
+the same host. Otherwise each sandbox re-downloads and re-stores the same
+JAR trees inside its own `agent-home`, adding several GB per project.
+
+The cache set is picked **per stack** — a project without a matching stack
+gets no shared cache mounts at all. Today only the JVM stack (`--stacks java`,
+also pulled in by `scala`) contributes cache entries; other language stacks
+are not supported now.
+
+Java/Scala cache mounts (all under `/home/vscode/` in the container):
+
+| Path                        | Cache for                                             |
+|-----------------------------|-------------------------------------------------------|
+| `.m2/repository/`           | Maven local repository                                |
+| `.cache/coursier/`          | Coursier — sbt (modern), scala-cli, Metals            |
+| `.gradle/caches/`           | Gradle dependency cache                               |
+| `.gradle/wrapper/dists/`    | Gradle Wrapper distributions                          |
+| `.ivy2/cache/`              | Ivy — legacy sbt (pre-Coursier resolver)              |
+| `.sbt/boot/`                | sbt bootstrap (sbt binaries + Scala compiler)         |
+
+Each is a Docker named volume with a stable host-wide name
+(`sandcat-cache-maven`, `sandcat-cache-coursier`, …) declared as
+`external: true` in the generated `compose-all.yml`. Multiple sandcat compose
+projects reference the same physical volume, and `sandcat compose down -v` on
+one project will **not** wipe caches other projects rely on. The `sandcat run`
+wrapper creates them lazily via `docker volume create` (idempotent), so no
+manual setup is required.
+
+Only `/home/vscode/.m2/repository/` is shared, not the whole `.m2/` — user
+config like `settings.xml` stays per-project inside `agent-home`. Same pattern
+for `.gradle/` (only `caches/` and `wrapper/dists/`, not `daemon/` or
+`init.d/`) and `.ivy2/` (only `cache/`, not `local/` where `sbt publishLocal`
+outputs live).
+
+**Opt out per project:**
+
+```bash
+sandcat init --features no-shared-cache ...      # interactive selection also
+                                                  # exposes it in the menu
+```
+
+Or set the env var before init (equivalent to the feature flag):
+
+```bash
+SANDCAT_MOUNT_SHARED_CACHE=false sandcat init ...
+```
+
+With shared cache disabled, the mount lines stay in `compose-all.yml` as
+comments — you can flip individual ones back on by uncommenting.
+
+**Trade-offs to be aware of:**
+
+* Shared caches break sandcat's per-project isolation model for those specific
+  paths. If one project's build corrupts a JAR (rare — Maven and Coursier both
+  do content-hash validation), other projects using shared cache pick up the
+  corruption. Disable per project if you need hermetic isolation (regulated
+  environments, security-sensitive projects).
+* Two parallel builds writing the same artifact rely on the tools' own file
+  locking (Maven `.locks/`, Coursier per-artifact `.lock`, Gradle `.lock`).
+  This works reliably in practice but is not sandcat-mediated.
+
+**Managing shared caches manually:**
+
+```bash
+# List
+docker volume ls | grep sandcat-cache-
+
+# Inspect size
+docker system df -v | grep sandcat-cache-
+
+# Wipe one (rebuild will re-download)
+docker volume rm sandcat-cache-maven
+
+# Wipe them all (aggressive — resets every JVM cache on the host)
+docker volume ls -q | grep '^sandcat-cache-' | xargs -r docker volume rm
+```
 
 ### 3. Start the sandbox
 

--- a/README.md
+++ b/README.md
@@ -315,21 +315,26 @@ comments — you can flip individual ones back on by uncommenting.
   locking (Maven `.locks/`, Coursier per-artifact `.lock`, Gradle `.lock`).
   This works reliably in practice but is not sandcat-mediated.
 
-**Managing shared caches manually:**
+**Managing shared caches:**
 
 ```bash
-# List
-docker volume ls | grep sandcat-cache-
+# Detailed table — volume name, size, file count, running container users
+sandcat cache list
+sandcat cache          # same as `list`
 
-# Inspect size
-docker system df -v | grep sandcat-cache-
+# Quick total across all shared-cache volumes
+sandcat cache size
 
-# Wipe one (rebuild will re-download)
-docker volume rm sandcat-cache-maven
+# Wipe one (next build re-downloads what the project needs)
+sandcat cache rm sandcat-cache-maven
 
-# Wipe them all (aggressive — resets every JVM cache on the host)
-docker volume ls -q | grep '^sandcat-cache-' | xargs -r docker volume rm
+# Wipe them all — resets every shared cache on the host
+sandcat cache rm --all
 ```
+
+`sandcat cache rm` refuses to remove a volume that a running sandbox
+still mounts; stop the sandbox first, or pass `--force` to bypass the
+check (Docker will then error out if the volume is truly locked).
 
 ### 3. Start the sandbox
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -131,6 +131,24 @@ Displays the current version of sandcat.
 Runs docker compose commands with the correct compose file automatically detected. Pass any docker compose arguments
 (e.g., `sandcat compose up -d` or `sandcat compose logs`).
 
+### `sandcat cache`
+
+Manages the host-scoped shared dependency-cache volumes (`sandcat-cache-*`)
+that back the shared-cache feature (see main README §*Shared dependency
+caches*). Bare `sandcat cache` is a shorthand for `sandcat cache list`.
+
+Subcommands:
+
+- `list` — print a table with volume name, size, file count, and any
+  running containers currently mounting it, plus a total-size row.
+- `size` — one-liner total size across every shared-cache volume on the
+  host.
+- `rm <volume>|--all [--force] [--yes]` — remove one or all shared-cache
+  volumes. Refuses by default when a running container still holds a
+  volume open; `--force` bypasses the check (Docker itself will still
+  refuse a truly locked volume). `--yes` skips the interactive
+  confirmation, for scripting.
+
 ### `sandcat edit compose`
 
 Opens the Docker Compose file in your editor. If you save changes and containers are running, it will restart containers by default to apply the changes.

--- a/cli/lib/cache.bash
+++ b/cli/lib/cache.bash
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Helpers for the `sandcat cache` command family — inspection and removal
+# of the host-scoped shared dependency-cache volumes declared by
+# add_shared_cache_volumes() in composefile.bash and lazily created by
+# ensure_shared_cache_volumes() in volume.bash.
+
+# Prints the names of all Docker volumes matching the sandcat shared-cache
+# label (sandcat-shared-cache=true), one per line. Empty output means no
+# shared caches exist yet on this host.
+sct_cache_volume_names() {
+	docker volume ls -q --filter label=sandcat-shared-cache=true 2>/dev/null | sort
+}
+
+# Prints the size of one volume in bytes. Uses a throwaway alpine
+# container to du(1) the mount point — Docker Desktop's VM makes host-side
+# introspection unreliable, so we go through a container instead.
+sct_cache_volume_size_bytes() {
+	local name=$1
+	docker run --rm -v "$name":/mnt alpine du -sb /mnt 2>/dev/null | awk '{print $1}'
+}
+
+# Formats a byte count into a human-readable string (e.g. "12.4 GB").
+sct_cache_format_bytes() {
+	local bytes=${1:-0}
+	awk -v b="$bytes" 'BEGIN {
+		split("B KB MB GB TB", units, " ");
+		i = 1;
+		while (b >= 1024 && i < 5) { b /= 1024; i++ }
+		if (i == 1) { printf "%d %s", b, units[i] }
+		else { printf "%.1f %s", b, units[i] }
+	}'
+}
+
+# Prints the number of file entries in a volume (recursive). Same
+# rationale as sct_cache_volume_size_bytes for going through a container.
+sct_cache_volume_file_count() {
+	local name=$1
+	docker run --rm -v "$name":/mnt alpine sh -c 'find /mnt -type f 2>/dev/null | wc -l' | awk '{print $1}'
+}
+
+# Prints the names of all containers currently mounting the given volume.
+# Empty output means the volume is free to remove.
+sct_cache_volume_containers() {
+	local name=$1
+	docker ps -a --filter volume="$name" --format '{{.Names}}' 2>/dev/null
+}

--- a/cli/lib/composefile.bash
+++ b/cli/lib/composefile.bash
@@ -20,12 +20,17 @@ source "$SCT_LIBDIR/agents.bash"
 #     driven by cursor.cli in Sandcat settings (not host-mounted).
 #   - SANDCAT_MOUNT_GIT_READONLY: "true" to mount .git directory as read-only
 #   - SANDCAT_MOUNT_IDEA_READONLY: "true" to mount .idea directory as read-only
+#   - SANDCAT_MOUNT_SHARED_CACHE: "true" (default) to mount shared JVM
+#     dependency-cache volumes (Maven, Coursier, Gradle, Ivy, sbt).
+#     Set to "false" to keep caches per-project inside agent-home.
 # Args:
 #   $1 - Path to the settings file to mount, relative to the Docker Compose file directory
 #   $2 - Path to the Docker Compose file to modify
 #   $3 - The agent name (e.g., "claude")
 #   $4 - The IDE name (e.g., "vscode", "jetbrains", "none") (optional)
 #   $5 - The project name (used to construct workspace paths) (required)
+#   $6 - Space-separated resolved stack names (used to pick shared caches;
+#        empty is fine — no caches added)
 #
 customize_compose_file() {
 	local settings_file=$1
@@ -33,6 +38,7 @@ customize_compose_file() {
 	local agent=$3
 	local ide=${4:-none}
 	local project_name=$5
+	local stacks=${6:-}
 
 	require yq
 
@@ -61,6 +67,12 @@ customize_compose_file() {
 
 	add_git_readonly_volume "$compose_file" "${SANDCAT_MOUNT_GIT_READONLY:=false}"
 	add_idea_readonly_volume "$compose_file" "${SANDCAT_MOUNT_IDEA_READONLY:-false}"
+
+	local -a stacks_arr=()
+	if [[ -n "$stacks" ]]; then
+		read -ra stacks_arr <<< "$stacks"
+	fi
+	add_shared_cache_volumes "$compose_file" "${SANDCAT_MOUNT_SHARED_CACHE:=true}" "${stacks_arr[@]+"${stacks_arr[@]}"}"
 
 	if [[ $ide == "jetbrains" ]]
 	then
@@ -302,6 +314,76 @@ add_idea_readonly_volume() {
 	local active=${2:-true}
 
 	add_volume_entry "$compose_file" '../.idea:/workspace/.idea:ro' "$active" 'Read-only IntelliJ IDEA project directory'
+}
+
+# Adds shared-cache mount entries + top-level external volume declarations
+# for the caches contributed by the selected stacks. Each stack decides
+# which caches it wants via stack_shared_cache_volumes() (see stacks.bash);
+# a project with no matching stack gets no shared-cache mounts at all.
+#
+# Volumes carry dependency caches that persist across all sandcat sandboxes
+# on the host, so multiple projects don't re-download the same JARs. They
+# are declared `external: true` so `sandcat compose down -v` on one project
+# doesn't wipe caches other projects rely on. The `sandcat run` wrapper
+# creates them lazily (idempotent) so users don't have to pre-create them.
+#
+# When active=false, matching mount lines are added as comments (matches
+# the existing pattern for optional mounts) so the user can uncomment or
+# re-enable later, and no external volumes are declared.
+#
+# Args:
+#   $1 - Path to the Docker Compose file
+#   $2 - true to add active mounts, false to add commented entries
+#   $3..$N - Resolved stack names (dependencies already expanded)
+add_shared_cache_volumes() {
+	require yq
+	# shellcheck source=stacks.bash
+	source "$SCT_LIBDIR/stacks.bash"
+
+	local compose_file=$1
+	local active=${2:-true}
+	shift 2
+
+	# Collect unique cache entries contributed by any selected stack.
+	# Stacks like scala pull java in via stack_deps, so their caches
+	# arrive here through the resolved list — no need to walk deps again.
+	local -a entries=()
+	local stack line seen
+	for stack in "$@"; do
+		while IFS= read -r line; do
+			[[ -n "$line" ]] || continue
+			seen=false
+			for existing in "${entries[@]+"${entries[@]}"}"; do
+				[[ "$existing" == "$line" ]] && seen=true && break
+			done
+			[[ "$seen" == "false" ]] && entries+=("$line")
+		done < <(stack_shared_cache_volumes "$stack")
+	done
+
+	[[ ${#entries[@]} -eq 0 ]] && return 0
+
+	local entry name path first=true
+	for entry in "${entries[@]}"; do
+		name=${entry%%:*}
+		path=${entry#*:}
+		if [[ $first == true ]]; then
+			first=false
+			add_volume_entry "$compose_file" "$name:$path" "$active" 'Shared dependency caches for the selected stacks (SANDCAT_MOUNT_SHARED_CACHE=false to disable)'
+		else
+			add_volume_entry "$compose_file" "$name:$path" "$active"
+		fi
+	done
+
+	# Declare each cache as an external volume with a stable host-scoped
+	# name so multiple compose projects reference the same physical volume.
+	if [[ $active == "true" ]]; then
+		for entry in "${entries[@]}"; do
+			name=${entry%%:*}
+			name="$name" yq -i \
+				'.volumes[env(name)] = {"external": true, "name": env(name)}' \
+				"$compose_file"
+		done
+	fi
 }
 
 # Sets the working directory and adds workspace volume mounts for the agent service.

--- a/cli/lib/stacks.bash
+++ b/cli/lib/stacks.bash
@@ -52,6 +52,32 @@ stack_deps() {
 	esac
 }
 
+# Shared JVM dependency caches. Six named volumes covering Maven, Coursier,
+# Gradle (deps + wrapper distributions), Ivy and sbt boot. Only the safe
+# subdirectories are exposed — `.m2/settings.xml`, `.gradle/daemon/`,
+# `.ivy2/local/` etc. stay per-project inside agent-home.
+SCT_STACK_CACHE_JAVA=(
+	"sandcat-cache-maven:/home/vscode/.m2/repository"
+	"sandcat-cache-coursier:/home/vscode/.cache/coursier"
+	"sandcat-cache-gradle:/home/vscode/.gradle/caches"
+	"sandcat-cache-gradle-wrapper:/home/vscode/.gradle/wrapper/dists"
+	"sandcat-cache-ivy:/home/vscode/.ivy2/cache"
+	"sandcat-cache-sbt-boot:/home/vscode/.sbt/boot"
+)
+
+# Returns newline-separated "<volume-name>:<container-path>" cache entries
+# contributed by a stack. Empty output means the stack has no shared caches
+# defined yet — that's the current state for every non-JVM stack.
+#
+# Scala inherits Java's caches via stack_deps: resolve_stacks() expands
+# `scala` to `java scala` before this is called, so the caller sees both
+# and dedups the union.
+stack_shared_cache_volumes() {
+	case $1 in
+		java) printf '%s\n' "${SCT_STACK_CACHE_JAVA[@]}" ;;
+	esac
+}
+
 # Resolves dependencies and deduplicates. Dependencies come before dependents.
 # Args: stack names
 # Output: space-separated resolved stack list

--- a/cli/lib/volume.bash
+++ b/cli/lib/volume.bash
@@ -49,3 +49,33 @@ warn_stale_home_volume() {
 	echo "To fix, stop containers and remove the volume:" | warning
 	echo "  sandcat compose down && docker volume rm $volume_name" | warning
 }
+
+# Ensures every external volume referenced by the compose file exists on
+# the host — otherwise `docker compose up` fails with "external volume
+# not found". Docker's `volume create` is idempotent, so we can call it
+# unconditionally on every sandcat run.
+#
+# Scoped to sandcat-cache-* names (the shared JVM dependency caches
+# declared by add_shared_cache_volumes). We deliberately don't touch
+# other external volumes users might add by hand.
+#
+# Args:
+#   $1 - Path to the compose file
+ensure_shared_cache_volumes() {
+	local compose_file=$1
+
+	command -v yq &>/dev/null || return 0
+	command -v docker &>/dev/null || return 0
+
+	local names
+	names=$(yq -r '.volumes // {} | to_entries[] | select(.value.external == true) | .value.name // .key' \
+		"$compose_file" 2>/dev/null | grep '^sandcat-cache-' || true)
+
+	[[ -n "$names" ]] || return 0
+
+	local name
+	while IFS= read -r name; do
+		[[ -n "$name" ]] || continue
+		docker volume create --label sandcat-shared-cache=true "$name" >/dev/null 2>&1 || true
+	done <<< "$names"
+}

--- a/cli/libexec/cache/cache
+++ b/cli/libexec/cache/cache
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default entry — with no subcommand, print `list`. `sandcat cache help`
+# is handled by the top-level dispatch.
+exec "$SCT_LIBEXECDIR/cache/list" "$@"

--- a/cli/libexec/cache/list
+++ b/cli/libexec/cache/list
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=../../lib/require.bash
+source "$SCT_LIBDIR/require.bash"
+# shellcheck source=../../lib/cache.bash
+source "$SCT_LIBDIR/cache.bash"
+
+# Lists every host-scoped shared-cache volume with its size, file count,
+# and any container currently mounting it.
+list() {
+	require docker
+
+	local -a names
+	mapfile -t names < <(sct_cache_volume_names)
+
+	if [[ ${#names[@]} -eq 0 ]]; then
+		echo "No sandcat shared-cache volumes on this host yet."
+		echo "They are created lazily on the first \`sandcat run\`."
+		return 0
+	fi
+
+	printf '%-32s %10s %8s  %s\n' "VOLUME" "SIZE" "FILES" "IN USE BY"
+	local name size_bytes size_human files users
+	local total_bytes=0
+	for name in "${names[@]}"; do
+		size_bytes=$(sct_cache_volume_size_bytes "$name")
+		size_bytes=${size_bytes:-0}
+		total_bytes=$((total_bytes + size_bytes))
+		size_human=$(sct_cache_format_bytes "$size_bytes")
+		files=$(sct_cache_volume_file_count "$name")
+		users=$(sct_cache_volume_containers "$name" | paste -sd, -)
+		[[ -z "$users" ]] && users="—"
+		printf '%-32s %10s %8s  %s\n' "$name" "$size_human" "$files" "$users"
+	done
+	printf '%-32s %10s\n' "" "$(sct_cache_format_bytes "$total_bytes") total"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	list "$@"
+fi

--- a/cli/libexec/cache/rm
+++ b/cli/libexec/cache/rm
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=../../lib/require.bash
+source "$SCT_LIBDIR/require.bash"
+# shellcheck source=../../lib/cache.bash
+source "$SCT_LIBDIR/cache.bash"
+# shellcheck source=../../lib/logging.bash
+source "$SCT_LIBDIR/logging.bash"
+
+# Removes one or all shared-cache volumes. Refuses (unless --force) when
+# a running container still holds a volume open, because docker rm would
+# fail with an unclear error and the user's build would keep behaving as
+# if the cache were live.
+usage() {
+	cat >&2 <<EOF
+Usage: sandcat cache rm <volume>|--all [--force] [--yes]
+
+  <volume>   Full volume name, e.g. sandcat-cache-maven.
+  --all      Remove every sandcat-shared-cache-labelled volume.
+  --force    Skip the "container still using this volume" check.
+  --yes      Skip the confirmation prompt.
+EOF
+	exit 1
+}
+
+rm_cmd() {
+	require docker
+
+	local target=""
+	local all=false force=false yes=false
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+			--all)   all=true ;;
+			--force) force=true ;;
+			--yes|-y) yes=true ;;
+			-h|--help) usage ;;
+			-*)      echo "Unknown flag: $1" >&2; usage ;;
+			*)       [[ -n "$target" ]] && { echo "Only one volume name accepted" >&2; usage; }
+			         target=$1 ;;
+		esac
+		shift
+	done
+
+	local -a targets=()
+	if [[ $all == "true" ]]; then
+		[[ -n "$target" ]] && { echo "Use --all OR a volume name, not both" >&2; usage; }
+		mapfile -t targets < <(sct_cache_volume_names)
+	else
+		[[ -z "$target" ]] && usage
+		targets=("$target")
+	fi
+
+	if [[ ${#targets[@]} -eq 0 ]]; then
+		echo "No matching shared-cache volumes found."
+		return 0
+	fi
+
+	# Container-in-use check first — abort BEFORE the confirmation prompt
+	# so the user isn't asked to confirm a removal that will fail.
+	if [[ $force != "true" ]]; then
+		local name in_use
+		for name in "${targets[@]}"; do
+			in_use=$(sct_cache_volume_containers "$name" | paste -sd, -)
+			if [[ -n "$in_use" ]]; then
+				echo "Cannot remove $name — in use by: $in_use" | error
+				echo "Stop those containers first, or pass --force." | error
+				exit 1
+			fi
+		done
+	fi
+
+	# Show what will happen + ask, unless --yes given.
+	if [[ $yes != "true" ]]; then
+		echo "The following shared-cache volumes will be removed from the host:"
+		local name
+		for name in "${targets[@]}"; do
+			echo "  - $name"
+		done
+		echo "This affects every sandcat sandbox that mounts them."
+		read -rp "Continue? [y/N] " reply
+		[[ "$reply" =~ ^[yY]$ ]] || { echo "Cancelled."; return 0; }
+	fi
+
+	# --force implies docker rm --force too, so an in-use volume yields
+	# a docker-native error (rare — we already checked, but belt+braces).
+	local rm_flags=()
+	[[ $force == "true" ]] && rm_flags+=(--force)
+
+	docker volume rm "${rm_flags[@]+"${rm_flags[@]}"}" "${targets[@]}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	rm_cmd "$@"
+fi

--- a/cli/libexec/cache/size
+++ b/cli/libexec/cache/size
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=../../lib/require.bash
+source "$SCT_LIBDIR/require.bash"
+# shellcheck source=../../lib/cache.bash
+source "$SCT_LIBDIR/cache.bash"
+
+# Prints the total size of all shared-cache volumes on this host — quick
+# one-liner useful for deciding whether it's worth cleaning up.
+size() {
+	require docker
+
+	local -a names
+	mapfile -t names < <(sct_cache_volume_names)
+
+	if [[ ${#names[@]} -eq 0 ]]; then
+		echo "0 B (no shared-cache volumes on this host)"
+		return 0
+	fi
+
+	local name size_bytes total_bytes=0
+	for name in "${names[@]}"; do
+		size_bytes=$(sct_cache_volume_size_bytes "$name")
+		total_bytes=$((total_bytes + ${size_bytes:-0}))
+	done
+	echo "$(sct_cache_format_bytes "$total_bytes") across ${#names[@]} volume(s)"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	size "$@"
+fi

--- a/cli/libexec/init/devcontainer
+++ b/cli/libexec/init/devcontainer
@@ -116,7 +116,7 @@ devcontainer() {
 
 	apply_secret_provider "$devcontainer_dir/sandcat/compose-proxy.yml" "$secret_provider"
 
-	customize_compose_file "$rel_settings_file" "$compose_file" "$agent" "$ide" "$project_name"
+	customize_compose_file "$rel_settings_file" "$compose_file" "$agent" "$ide" "$project_name" "$stacks"
 	set_project_name "$compose_file" "$project_name"
 
 	customize_devcontainer_json "$devcontainer_dir/devcontainer.json" "$project_name" "$ide"

--- a/cli/libexec/init/init
+++ b/cli/libexec/init/init
@@ -270,10 +270,13 @@ init() {
 		return 1
 	fi
 
-	# Optional non-provider features (tui → mitmproxy console)
+	# Optional non-provider features
+	#   tui             → mitmproxy console instead of web UI
+	#   no-shared-cache → disable shared JVM dependency cache volumes
 	if [[ "$features_provided" != "true" ]]; then
 		local available_features=(
 			"tui (mitmproxy console instead of web UI)"
+			"no-shared-cache (per-project dep cache instead of shared)"
 		)
 		local selected_features
 		selected_features=$(select_multiple "Select optional features (comma-separated numbers, empty for none):" "${available_features[@]}")
@@ -283,6 +286,7 @@ init() {
 			for f in $selected_features; do
 				case "$f" in
 					tui) proxy_mode="tui" ;;
+					no-shared-cache) export SANDCAT_MOUNT_SHARED_CACHE="false" ;;
 				esac
 			done
 		fi
@@ -292,11 +296,12 @@ init() {
 			for f in $features_csv; do
 				case "$f" in
 					tui) proxy_mode="tui" ;;
+					no-shared-cache) export SANDCAT_MOUNT_SHARED_CACHE="false" ;;
 					1password)
 						echo "Use --secret-provider 1password instead of --features 1password" | error
 						return 1
 						;;
-					*) echo "Unknown feature: $f (expected: tui)" | error; return 1 ;;
+					*) echo "Unknown feature: $f (expected: tui, no-shared-cache)" | error; return 1 ;;
 				esac
 			done
 		fi

--- a/cli/libexec/run/run
+++ b/cli/libexec/run/run
@@ -36,6 +36,7 @@ run() {
 	done
 
 	warn_stale_home_volume "$compose_file"
+	ensure_shared_cache_volumes "$compose_file"
 
 	local rc=0
 	docker compose -f "$compose_file" run --rm "${run_opts[@]+"${run_opts[@]}"}" agent "${1-bash}" "${@:2}" || rc=$?

--- a/cli/templates/devcontainer/sandcat/scripts/app-init.sh
+++ b/cli/templates/devcontainer/sandcat/scripts/app-init.sh
@@ -136,6 +136,36 @@ if [ -f "$SNAPSHOT_HASH_FILE" ]; then
     fi
 fi
 
+# Shared-cache volumes (sandcat-cache-*) arrive as root:root because
+# `docker volume create` produces empty root-owned volumes and Docker
+# also creates any intermediate parent directories on the mount path as
+# root when they don't yet exist in the image (e.g. .gradle/ when
+# .gradle/caches/ is the mount target). Normalise ownership on both the
+# mount roots and the intermediate parents so vscode can lay down
+# tool-generated siblings like .m2/settings.xml or .gradle/daemon/.
+#
+# Only the listed directories are touched (non-recursive) — volumes
+# shared with other projects can hold thousands of files, and the tools
+# we care about only need the top-level dirs writable.
+for cache_dir in \
+    /home/vscode/.m2 \
+    /home/vscode/.m2/repository \
+    /home/vscode/.cache \
+    /home/vscode/.cache/coursier \
+    /home/vscode/.gradle \
+    /home/vscode/.gradle/wrapper \
+    /home/vscode/.gradle/caches \
+    /home/vscode/.gradle/wrapper/dists \
+    /home/vscode/.ivy2 \
+    /home/vscode/.ivy2/cache \
+    /home/vscode/.sbt \
+    /home/vscode/.sbt/boot
+do
+    if [ -d "$cache_dir" ]; then
+        chown vscode:vscode "$cache_dir" 2>/dev/null || true
+    fi
+done
+
 # Run vscode-user tasks in a login shell so user profile customizations
 # (PATH/NVM/direnv, etc.) are applied. Re-source sandcat.env inside that
 # shell so app-user-init still receives sandcat placeholders and env vars.

--- a/cli/test/cache/cache.bats
+++ b/cli/test/cache/cache.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
+
+setup() {
+	load test_helper
+	# shellcheck source=../../lib/cache.bash
+	source "$SCT_LIBDIR/cache.bash"
+}
+
+teardown() {
+	unstub_all 2>/dev/null || true
+}
+
+# --- helpers -----------------------------------------------------------------
+
+@test "sct_cache_format_bytes formats bytes/KB/MB/GB" {
+	run sct_cache_format_bytes 0
+	assert_output "0 B"
+	run sct_cache_format_bytes 512
+	assert_output "512 B"
+	run sct_cache_format_bytes 2048
+	assert_output "2.0 KB"
+	run sct_cache_format_bytes $((5 * 1024 * 1024))
+	assert_output "5.0 MB"
+	run sct_cache_format_bytes $((2 * 1024 * 1024 * 1024))
+	assert_output "2.0 GB"
+}
+
+@test "sct_cache_volume_names filters by shared-cache label" {
+	stub docker \
+		"volume ls -q --filter label=sandcat-shared-cache=true : printf 'sandcat-cache-maven\nsandcat-cache-coursier\n'"
+
+	run sct_cache_volume_names
+	assert_success
+	assert_line --index 0 "sandcat-cache-coursier"
+	assert_line --index 1 "sandcat-cache-maven"
+}
+
+# --- cache list --------------------------------------------------------------
+
+@test "cache list — empty state prints the lazy-create hint" {
+	stub docker \
+		"volume ls -q --filter label=sandcat-shared-cache=true : :"
+
+	run "$SCT_LIBEXECDIR/cache/list"
+	assert_success
+	assert_output --partial "No sandcat shared-cache volumes"
+	assert_output --partial "lazily on the first"
+}
+
+@test "cache list — prints one row per volume with size + files + user" {
+	# One volume, one running container using it, ~2.5 KB, 5 files.
+	stub docker \
+		"volume ls -q --filter label=sandcat-shared-cache=true : echo sandcat-cache-maven" \
+		"run --rm -v sandcat-cache-maven:/mnt alpine du -sb /mnt : printf '2560\t/mnt\n'" \
+		"run --rm -v sandcat-cache-maven:/mnt alpine sh -c 'find /mnt -type f 2>/dev/null | wc -l' : echo '     5'" \
+		"ps -a --filter volume=sandcat-cache-maven --format {{.Names}} : echo agent-A"
+
+	run "$SCT_LIBEXECDIR/cache/list"
+	assert_success
+	assert_output --partial "VOLUME"
+	assert_output --partial "sandcat-cache-maven"
+	assert_output --partial "2.5 KB"
+	assert_output --partial "agent-A"
+	assert_output --partial "2.5 KB total"
+}
+
+@test "cache list — no user column shows em-dash" {
+	stub docker \
+		"volume ls -q --filter label=sandcat-shared-cache=true : echo sandcat-cache-ivy" \
+		"run --rm -v sandcat-cache-ivy:/mnt alpine du -sb /mnt : printf '0\t/mnt\n'" \
+		"run --rm -v sandcat-cache-ivy:/mnt alpine sh -c 'find /mnt -type f 2>/dev/null | wc -l' : echo '0'" \
+		"ps -a --filter volume=sandcat-cache-ivy --format {{.Names}} : :"
+
+	run "$SCT_LIBEXECDIR/cache/list"
+	assert_success
+	assert_output --partial "—"
+}
+
+# --- cache size --------------------------------------------------------------
+
+@test "cache size — 0 B when no volumes" {
+	stub docker \
+		"volume ls -q --filter label=sandcat-shared-cache=true : :"
+
+	run "$SCT_LIBEXECDIR/cache/size"
+	assert_success
+	assert_output --partial "0 B (no shared-cache volumes"
+}
+
+@test "cache size — sums bytes across all volumes" {
+	# Two volumes, ~1 MB + ~2 MB = ~3 MB.
+	stub docker \
+		"volume ls -q --filter label=sandcat-shared-cache=true : printf 'sandcat-cache-maven\nsandcat-cache-coursier\n'" \
+		"run --rm -v sandcat-cache-coursier:/mnt alpine du -sb /mnt : printf '1048576\t/mnt\n'" \
+		"run --rm -v sandcat-cache-maven:/mnt alpine du -sb /mnt : printf '2097152\t/mnt\n'"
+
+	run "$SCT_LIBEXECDIR/cache/size"
+	assert_success
+	assert_output --partial "3.0 MB across 2 volume(s)"
+}
+
+# --- cache rm ----------------------------------------------------------------
+
+@test "cache rm — refuses when volume in use unless --force" {
+	# ps returns a container name → in-use → abort before any docker rm.
+	stub docker \
+		"ps -a --filter volume=sandcat-cache-maven --format {{.Names}} : echo running-agent-1"
+
+	run "$SCT_LIBEXECDIR/cache/rm" --yes sandcat-cache-maven
+	assert_failure
+	assert_output --partial "in use by: running-agent-1"
+	assert_output --partial "--force"
+}
+
+@test "cache rm — deletes the named volume when free" {
+	stub docker \
+		"ps -a --filter volume=sandcat-cache-maven --format {{.Names}} : :" \
+		"volume rm sandcat-cache-maven : echo sandcat-cache-maven"
+
+	run "$SCT_LIBEXECDIR/cache/rm" --yes sandcat-cache-maven
+	assert_success
+	assert_output --partial "sandcat-cache-maven"
+}
+
+@test "cache rm --all — deletes every discovered volume" {
+	stub docker \
+		"volume ls -q --filter label=sandcat-shared-cache=true : printf 'sandcat-cache-maven\nsandcat-cache-coursier\n'" \
+		"ps -a --filter volume=sandcat-cache-coursier --format {{.Names}} : :" \
+		"ps -a --filter volume=sandcat-cache-maven --format {{.Names}} : :" \
+		"volume rm sandcat-cache-coursier sandcat-cache-maven : printf 'sandcat-cache-coursier\nsandcat-cache-maven\n'"
+
+	run "$SCT_LIBEXECDIR/cache/rm" --all --yes
+	assert_success
+	assert_output --partial "sandcat-cache-coursier"
+	assert_output --partial "sandcat-cache-maven"
+}
+
+@test "cache rm --force skips in-use check" {
+	# No ps call because --force bypasses; docker volume rm --force runs.
+	stub docker \
+		"volume rm --force sandcat-cache-maven : echo sandcat-cache-maven"
+
+	run "$SCT_LIBEXECDIR/cache/rm" --force --yes sandcat-cache-maven
+	assert_success
+}
+
+@test "cache rm — rejects mixing --all with a volume name" {
+	run "$SCT_LIBEXECDIR/cache/rm" --all sandcat-cache-maven
+	assert_failure
+	assert_output --partial "Use --all OR a volume name"
+}
+
+@test "cache rm — no args prints usage" {
+	run "$SCT_LIBEXECDIR/cache/rm"
+	assert_failure
+	assert_output --partial "Usage:"
+}

--- a/cli/test/cache/test_helper.bash
+++ b/cli/test/cache/test_helper.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+bats_require_minimum_version 1.5.0
+
+if shopt -s compat32 2>/dev/null; then
+	export BASH_COMPAT=3.2
+fi
+set -uo pipefail
+export SHELLOPTS
+
+SCT_ROOT="$BATS_TEST_DIRNAME/../.."
+
+BATS_LIB_PATH="$SCT_ROOT/support":${BATS_LIB_PATH-}
+
+bats_load_library bats-ext
+bats_load_library bats-support
+bats_load_library bats-assert
+bats_load_library bats-mock-ext
+
+export SCT_ROOT
+export SCT_LIBDIR="$SCT_ROOT/lib"
+export SCT_LIBEXECDIR="$SCT_ROOT/libexec"

--- a/cli/test/composefile/composefile.bats
+++ b/cli/test/composefile/composefile.bats
@@ -96,6 +96,136 @@ teardown() {
 	yq -e '.services.agent.volumes[] | select(. == "../.idea:/workspace/.idea:ro")' "$COMPOSE_FILE"
 }
 
+@test "add_shared_cache_volumes with java stack mounts all six JVM cache paths" {
+	# shellcheck source=../../lib/stacks.bash
+	source "$SCT_LIBDIR/stacks.bash"
+
+	add_shared_cache_volumes "$COMPOSE_FILE" "true" "java"
+
+	# Every SCT_STACK_CACHE_JAVA entry becomes an active volume mount.
+	local entry name path
+	for entry in "${SCT_STACK_CACHE_JAVA[@]}"; do
+		name=${entry%%:*}
+		path=${entry#*:}
+		mount="$name:$path" yq -e \
+			'.services.agent.volumes[] | select(. == env(mount))' "$COMPOSE_FILE"
+	done
+}
+
+@test "add_shared_cache_volumes declares each cache as an external top-level volume" {
+	source "$SCT_LIBDIR/stacks.bash"
+
+	add_shared_cache_volumes "$COMPOSE_FILE" "true" "java"
+
+	# Each cache lives under a stable host-scoped name so multiple compose
+	# projects reference the same physical volume; external:true prevents
+	# `compose down -v` in one project from wiping caches shared elsewhere.
+	local entry name
+	for entry in "${SCT_STACK_CACHE_JAVA[@]}"; do
+		name=${entry%%:*}
+		name="$name" yq -e '.volumes[env(name)].external == true' "$COMPOSE_FILE"
+		name="$name" yq -e '.volumes[env(name)].name == env(name)' "$COMPOSE_FILE"
+	done
+}
+
+@test "add_shared_cache_volumes adds nothing when no matching stack is selected" {
+	# python/node/etc. don't contribute shared caches yet — the compose
+	# file must stay clean of Maven/Coursier/etc. mounts. This is the
+	# case for a Python-only sandbox, which shouldn't carry JVM caches.
+	add_shared_cache_volumes "$COMPOSE_FILE" "true" "python" "node"
+
+	run yq -r '.volumes // {} | keys[]' "$COMPOSE_FILE"
+	refute_output --partial "sandcat-cache-"
+
+	run grep -F 'sandcat-cache-' "$COMPOSE_FILE"
+	assert_failure
+}
+
+@test "add_shared_cache_volumes deduplicates when java appears via multiple stacks" {
+	source "$SCT_LIBDIR/stacks.bash"
+
+	# resolve_stacks expands "scala" to "java scala"; simulate that flow.
+	add_shared_cache_volumes "$COMPOSE_FILE" "true" "java" "scala"
+
+	# Still exactly the six Java entries — no duplicate top-level volumes.
+	local expected_count=${#SCT_STACK_CACHE_JAVA[@]}
+	run yq -r '.volumes | keys | length' "$COMPOSE_FILE"
+	assert_output "$expected_count"
+}
+
+@test "add_shared_cache_volumes leaves entries commented when active=false" {
+	source "$SCT_LIBDIR/stacks.bash"
+
+	add_shared_cache_volumes "$COMPOSE_FILE" "false" "java"
+
+	# No active mounts appear.
+	local entry name
+	for entry in "${SCT_STACK_CACHE_JAVA[@]}"; do
+		name=${entry%%:*}
+		run yq -r '.services.agent.volumes[] | select(. == "'"$name"':*")' "$COMPOSE_FILE"
+		assert_output ""
+	done
+
+	# No top-level external volumes are declared either.
+	for entry in "${SCT_STACK_CACHE_JAVA[@]}"; do
+		name=${entry%%:*}
+		run bash -c "name='$name' yq -r '.volumes // {} | keys[]' '$COMPOSE_FILE' | grep -q \"^\$name\$\""
+		assert_failure
+	done
+
+	# Comment lines with the mount specs stay in the file so users can
+	# uncomment later.
+	run grep -F "sandcat-cache-maven:/home/vscode/.m2/repository" "$COMPOSE_FILE"
+	assert_success
+}
+
+@test "app-init.sh normalises ownership on every shared-cache mount point" {
+	# Docker creates named volumes as root:root. Without a startup chown,
+	# vscode can't write to /home/vscode/.m2/repository etc. — the whole
+	# shared-cache feature would appear broken with permission-denied.
+	local script="$SCT_TEMPLATEDIR/devcontainer/sandcat/scripts/app-init.sh"
+	run grep -F 'chown vscode:vscode "$cache_dir"' "$script"
+	assert_success
+
+	# Every mount root + its intermediate parent must be in the loop, so
+	# tools that also write next to the mount (Maven settings.xml, Gradle
+	# daemon/, etc.) don't fail on the root-owned parent dir.
+	local dir
+	for dir in \
+		/home/vscode/.m2 \
+		/home/vscode/.m2/repository \
+		/home/vscode/.cache \
+		/home/vscode/.cache/coursier \
+		/home/vscode/.gradle \
+		/home/vscode/.gradle/wrapper \
+		/home/vscode/.gradle/caches \
+		/home/vscode/.gradle/wrapper/dists \
+		/home/vscode/.ivy2 \
+		/home/vscode/.ivy2/cache \
+		/home/vscode/.sbt \
+		/home/vscode/.sbt/boot
+	do
+		run grep -F "$dir" "$script"
+		assert_success
+	done
+}
+
+@test "customize_compose_file honours SANDCAT_MOUNT_SHARED_CACHE=false" {
+	# The env-var toggle is the primary opt-out path. Even for a java
+	# stack that normally gets shared caches, disabling the flag must
+	# keep the compose file free of shared-cache mounts + external
+	# volume declarations.
+	SETTINGS_FILE=".sandcat/settings.json"
+	mkdir -p "$BATS_TEST_TMPDIR/.sandcat"
+	touch "$BATS_TEST_TMPDIR/$SETTINGS_FILE"
+
+	SANDCAT_MOUNT_SHARED_CACHE=false \
+		customize_compose_file "$SETTINGS_FILE" "$COMPOSE_FILE" "claude" "vscode" "test-project" "java"
+
+	run yq -r '.volumes // {} | keys[]' "$COMPOSE_FILE"
+	refute_output --partial "sandcat-cache-"
+}
+
 assert_jetbrains_capabilities() {
 	local compose_file=$1
 
@@ -213,8 +343,9 @@ EOF
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.claude/agents:/home/vscode/.claude/agents:ro")' "$COMPOSE_FILE"
 	yq -e '.services.agent.volumes[] | select(. == "${HOME}/.claude/commands:/home/vscode/.claude/commands:ro")' "$COMPOSE_FILE"
 
-	# With JetBrains IDE, the .idea mount is also active by default
-	# 1 initial + 3 workspace + 3 Claude + 1 .idea = 8 active volumes
+	# With JetBrains IDE, the .idea mount is also active by default.
+	# 1 initial + 3 workspace + 3 Claude + 1 .idea = 8 active volumes.
+	# No shared-cache volumes because this call passes no stacks.
 	run yq '.services.agent.volumes | length' "$COMPOSE_FILE"
 	assert_output "8"
 }

--- a/cli/test/composefile/test_helper.bash
+++ b/cli/test/composefile/test_helper.bash
@@ -21,3 +21,4 @@ bats_load_library bats-mock-ext
 
 export SCT_ROOT
 export SCT_LIBDIR="$SCT_ROOT/lib"
+export SCT_TEMPLATEDIR="$SCT_ROOT/templates"

--- a/cli/test/init/init.bats
+++ b/cli/test/init/init.bats
@@ -141,7 +141,7 @@ teardown() {
 		"'Select IDE:' vscode jetbrains none : echo vscode" \
 		"'Select secret provider:' 1password none protonpass : echo 1password"
 	stub select_multiple \
-		"'Select optional features (comma-separated numbers, empty for none):' 'tui (mitmproxy console instead of web UI)' : echo ''" \
+		"'Select optional features (comma-separated numbers, empty for none):' 'tui (mitmproxy console instead of web UI)' 'no-shared-cache (per-project dep cache instead of shared)' : echo ''" \
 		"'Select development stacks (comma-separated numbers, empty for none):' node python java rust go scala ruby dotnet zig : echo ''"
 
 	local expected_name
@@ -222,7 +222,7 @@ teardown() {
 		"'Select IDE:' vscode jetbrains none : echo vscode" \
 		"'Select secret provider:' none 1password protonpass : echo none"
 	stub select_multiple \
-		"'Select optional features (comma-separated numbers, empty for none):' 'tui (mitmproxy console instead of web UI)' : echo ''" \
+		"'Select optional features (comma-separated numbers, empty for none):' 'tui (mitmproxy console instead of web UI)' 'no-shared-cache (per-project dep cache instead of shared)' : echo ''" \
 		"'Select development stacks (comma-separated numbers, empty for none):' node python java rust go scala ruby dotnet zig : echo ''"
 
 	local expected_name
@@ -258,10 +258,34 @@ teardown() {
 	assert_success
 }
 
-@test "init rejects unknown feature listing tui" {
+@test "init --features no-shared-cache exports SANDCAT_MOUNT_SHARED_CACHE=false" {
+	# The devcontainer stub echoes the env var so we can assert it
+	# propagated across the sub-command boundary via `export`.
+	stub settings "$PROJECT_DIR/.sandcat/settings.json claude vscode : :"
+	stub devcontainer \
+		"--settings-file .sandcat/settings.json --project-path * --agent claude --ide vscode --name test --stacks * --proxy web --secret-provider none : echo \"SHARED=\$SANDCAT_MOUNT_SHARED_CACHE\""
+
+	run init --agent claude --ide vscode --name test --path "$PROJECT_DIR" --stacks "" --features "no-shared-cache" --secret-provider none
+	assert_success
+	assert_output --partial "SHARED=false"
+}
+
+@test "init --features tui,no-shared-cache accepts both" {
+	stub settings "$PROJECT_DIR/.sandcat/settings.json claude vscode : :"
+	stub devcontainer \
+		"--settings-file .sandcat/settings.json --project-path * --agent claude --ide vscode --name test --stacks * --proxy tui --secret-provider none : echo \"SHARED=\$SANDCAT_MOUNT_SHARED_CACHE\""
+
+	run init --agent claude --ide vscode --name test --path "$PROJECT_DIR" --stacks "" --features "tui,no-shared-cache" --secret-provider none
+	assert_success
+	assert_output --partial "SHARED=false"
+}
+
+@test "init rejects unknown feature and lists all supported ones" {
 	run init --agent claude --ide vscode --name test --path "$PROJECT_DIR" --stacks "" --features "bogus" --secret-provider none
 	assert_failure
-	assert_output --partial "Unknown feature: bogus (expected: tui)"
+	assert_output --partial "Unknown feature: bogus"
+	assert_output --partial "tui"
+	assert_output --partial "no-shared-cache"
 }
 
 @test "init interactive feature selection applies tui from full labels" {
@@ -275,7 +299,7 @@ teardown() {
 		"'Select IDE:' vscode jetbrains none : echo vscode" \
 		"'Select secret provider:' none 1password protonpass : echo none"
 	stub select_multiple \
-		"'Select optional features (comma-separated numbers, empty for none):' 'tui (mitmproxy console instead of web UI)' : echo 'tui (mitmproxy console instead of web UI)'" \
+		"'Select optional features (comma-separated numbers, empty for none):' 'tui (mitmproxy console instead of web UI)' 'no-shared-cache (per-project dep cache instead of shared)' : echo 'tui (mitmproxy console instead of web UI)'" \
 		"'Select development stacks (comma-separated numbers, empty for none):' node python java rust go scala ruby dotnet zig : echo ''"
 
 	local expected_name

--- a/cli/test/init/stacks.bats
+++ b/cli/test/init/stacks.bats
@@ -139,3 +139,41 @@ teardown() {
 	assert_failure
 	assert_output --partial "expected:"
 }
+
+@test "stack_shared_cache_volumes returns six entries for java" {
+	run stack_shared_cache_volumes java
+	assert_success
+	# One line per cache mount, all in "<volume-name>:<container-path>" form.
+	assert_output --partial "sandcat-cache-maven:/home/vscode/.m2/repository"
+	assert_output --partial "sandcat-cache-coursier:/home/vscode/.cache/coursier"
+	assert_output --partial "sandcat-cache-gradle:/home/vscode/.gradle/caches"
+	assert_output --partial "sandcat-cache-gradle-wrapper:/home/vscode/.gradle/wrapper/dists"
+	assert_output --partial "sandcat-cache-ivy:/home/vscode/.ivy2/cache"
+	assert_output --partial "sandcat-cache-sbt-boot:/home/vscode/.sbt/boot"
+
+	local count
+	count=$(stack_shared_cache_volumes java | wc -l)
+	[ "$count" -eq 6 ]
+}
+
+@test "stack_shared_cache_volumes returns empty for stacks without a defined cache set" {
+	# Non-JVM stacks currently contribute no shared caches. Adding
+	# more (npm, cargo, pip) is a follow-up.
+	for stack in node python rust go ruby dotnet zig; do
+		run stack_shared_cache_volumes "$stack"
+		assert_success
+		[ -z "$output" ] || { echo "expected empty for $stack, got: $output"; return 1; }
+	done
+}
+
+@test "stack_shared_cache_volumes for scala relies on stack_deps expansion" {
+	# scala itself contributes nothing directly — java's caches arrive
+	# via resolve_stacks, which callers use to expand dependencies before
+	# passing the list into add_shared_cache_volumes.
+	run stack_shared_cache_volumes scala
+	assert_success
+	[ -z "$output" ]
+
+	run resolve_stacks scala
+	assert_output "java scala"
+}


### PR DESCRIPTION
Adds shared, host-scoped Docker volumes for JVM dependency caches
(Maven, Coursier, Gradle, Ivy, sbt) so multiple sandcat sandboxes on
the same host share one copy of `cats-effect`, `spring-boot`, etc.
instead of each downloading and storing their own. Also ships a
`sandcat cache` command family for inspecting and cleaning up those
volumes without dropping into raw docker.

## Why

Every sandcat sandbox stores its Maven/Coursier/Gradle caches inside
its per-project `agent-home` volume. A team with five JVM projects
easily runs 10–30 GB of duplicated JAR trees; every fresh sandbox
re-downloads the same artifacts through mitmproxy on first build.

## Design

Per-stack, opt-out, six volumes for the JVM stack:

| Path (in container)         | Volume                          | Contents                              |
|-----------------------------|---------------------------------|---------------------------------------|
| `.m2/repository/`           | `sandcat-cache-maven`           | Maven local repository                |
| `.cache/coursier/`          | `sandcat-cache-coursier`        | Coursier — modern sbt / scala-cli / Metals |
| `.gradle/caches/`           | `sandcat-cache-gradle`          | Gradle dependency cache               |
| `.gradle/wrapper/dists/`    | `sandcat-cache-gradle-wrapper`  | Gradle Wrapper distributions          |
| `.ivy2/cache/`              | `sandcat-cache-ivy`             | Ivy — legacy sbt                      |
| `.sbt/boot/`                | `sandcat-cache-sbt-boot`        | sbt bootstrap + Scala compiler        |

Only the safe subdirectories are shared. `.m2/settings.xml` (user
config, potentially secrets), `.gradle/daemon/` (per-process state),
`.gradle/init.d/`, `.gradle/gradle.properties`, and `.ivy2/local/`
(local `publishLocal` output — per-project semantics) all stay in the
per-project `agent-home`. Nested Linux mount stacking keeps the split
transparent to build tools.

**Per-stack.** Each stack picks its cache set via a new
`stack_shared_cache_volumes()` in `cli/lib/stacks.bash`. Today only
`java` (and via `stack_deps`: `scala`) contributes cache entries — a
Python-only sandbox stays clean of Maven mounts. Adding npm/cargo/pip
sets for the other stacks in the same shape is a follow-up.

**Docker mechanics.** Volumes declared `external: true` with a stable
host-wide name in the generated `compose-all.yml`, so
`sandcat compose down -v` in one project doesn't wipe caches shared
with others. `sandcat run` creates them lazily via
`docker volume create --label sandcat-shared-cache=true` (idempotent) —
no manual pre-creation.

## `sandcat cache` command family

Wrappers over the raw `docker volume`/`docker system df` plumbing so
users don't have to memorise labels and pipelines:

```
sandcat cache            # same as `list`
sandcat cache list       # table: name, size, file count, in-use-by
sandcat cache size       # one-liner total across all shared caches
sandcat cache rm <name>|--all [--force] [--yes]
```

`rm` refuses by default when a running container still mounts a
target volume — users get a clear message ("in use by …, stop those
first or pass --force") instead of docker's cryptic error. `--force`
bypasses the pre-check, `--yes` skips the interactive prompt for
scripting.

## Opt-out

Default is on for JVM stacks. Two equivalent switches:

```bash
sandcat init --features no-shared-cache ...   # interactive menu also
                                              # exposes it
SANDCAT_MOUNT_SHARED_CACHE=false sandcat init ...
```

Disabled → the six mount entries stay in `compose-all.yml` as
comments (matches the existing pattern for other optional mounts),
and no external volumes are declared. Users can uncomment individual
ones later.

## Trade-offs

* **Isolation.** Shared caches break sandcat's per-project isolation
  for those specific paths. If one build corrupts a JAR (rare — Maven
  and Coursier both do content-hash validation), other projects using
  the shared cache pick up the corruption. Users needing hermetic
  isolation (regulated environments, security-sensitive projects) can
  opt out per project.
* **Concurrent writes.** Two parallel builds writing the same artifact
  rely on the tools' own file locking (Maven `.locks/`, Coursier
  per-artifact `.lock`, Gradle `.lock`). Works reliably in practice
  but is not sandcat-mediated.

## Test plan

- [x] `bats cli/test/composefile/composefile.bats` — new tests cover
      per-stack mount emission, external-volume declaration, empty
      compose for non-JVM projects, comment-out path when disabled,
      env-var opt-out, and the app-init.sh chown loop content
- [x] `bats cli/test/init/init.bats` — new tests cover
      `--features no-shared-cache` env-var propagation, combining with
      `--features tui`, and error message listing every supported
      feature
- [x] `bats cli/test/init/stacks.bats` — new tests cover
      `stack_shared_cache_volumes` returning six Java entries, empty
      for other stacks, and Scala relying on `stack_deps` expansion
- [x] `bats cli/test/cache/cache.bats` — new suite covers the CLI
      command family (helpers, list output, size summation, rm
      in-use refusal, --all, --force, argument validation)
- [x] `./cli/run-tests.bash` — full suite ~150 s, no regressions
- [x] End-to-end: `sandcat init --ide jetbrains --stacks scala`, build,
      `sbt update` pulling in `cats-effect:3.5.4` — cats-effect JAR +
      trans deps (107 MB, 1550 files) land in `sandcat-cache-coursier`
      and are readable from an independent `docker run --rm alpine`
      container mounting the same volume. sbt bootstrap (72 MB) in
      `sandcat-cache-sbt-boot`. Other cache volumes (maven/ivy/gradle)
      remain empty as expected (sbt with Coursier resolver uses
      Coursier, not Maven/Ivy).
- [x] `sandcat cache list`/`size` output verified live against the
      populated caches
- [x] `sandcat cache rm` refuses in-use volume, deletes free volume,
      `--all` bulk deletes, `--yes` skips prompt

## Follow-ups (not in this PR)

* npm/pip/cargo/go-modules cache sets for the other stacks (same
  `stack_shared_cache_volumes()` shape)
* Optional `sandcat cache gc` to prune orphaned caches whose stacks
  are no longer defined