### PR TITLE
Correct specification of nix nodejs lts

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ At image build time the two files are merged into a single devbox global
 config. `devbox.tools.json` wins over `devbox.stack.json` on:
 
 * **Same package name** — the `@` prefix. Put `nodejs@22.5.1` in tools
-  to replace the stack's `nodejs@lts`.
+  to replace the stack's `nodejs` (without a specifier, `nodejs` refers to lts).
 * **Cross-family collisions** — tools packages providing the same file
   as a stack package win too. Put `openjdk17@latest` in tools to make
   it the active Java over the stack's `temurin-bin-25@latest`; the

--- a/cli/lib/devbox.bash
+++ b/cli/lib/devbox.bash
@@ -92,7 +92,7 @@ EOF
 # jq program that merges two devbox configs into one. When both files
 # list a package with the same name (part before '@'), the entry from
 # devbox.tools.json wins — that's the primary way to override a stack
-# default (e.g. `nodejs@22.5.1` in tools replaces stack's `nodejs@lts`).
+# default (e.g. `nodejs@22.5.1` in tools replaces stack's `nodejs`).
 #
 # For cross-family collisions (e.g. tools ships `openjdk17@latest` while
 # stack ships `temurin-bin-25@latest`, both providing bin/java), the merge

--- a/cli/lib/stacks.bash
+++ b/cli/lib/stacks.bash
@@ -16,7 +16,7 @@ STACK_NAMES=(node python java rust go scala ruby dotnet zig)
 # detection against the same package name.
 stack_devbox_packages() {
 	case $1 in
-		node)   echo "nodejs@lts" ;;
+		node)   echo "nodejs" ;;
 		python) echo "python@latest" ;;
 		java)   echo "temurin-bin-25@latest" ;;
 		rust)   echo "rustc@latest cargo@latest" ;;

--- a/cli/test/init/stacks.bats
+++ b/cli/test/init/stacks.bats
@@ -13,7 +13,7 @@ teardown() {
 
 @test "stack_devbox_packages returns package specs for each stack" {
 	run stack_devbox_packages node
-	assert_output "nodejs@lts"
+	assert_output "nodejs"
 
 	run stack_devbox_packages python
 	assert_output "python@latest"


### PR DESCRIPTION
In this PR, I fixed an issue that prevented me from using the nodejs stack with sandcat.

As far as I can tell from my experimentation and from [the docs](https://nixos.wiki/wiki/Node.js), the correct way to specify nodejs lts is simply "nodejs".

Below is an abbreviated terminal session that shows the issue. Notice `Error: nodejs@lts: package not found` and notice that correcting the version specifier results in installing `v24.18.1` as expected. I have also tried this with `@latest` and it installs a more recent node.js than the lts.

```
~/sandcat-nodejs-lts-issue
❯ echo | sandcat init --name wololo --agent claude --ide vscode --stacks node --secret-provider none

[blah...]

~/sandcat-nodejs-lts-issue
❯ cat .devcontainer/devbox.stack.json 
{
  "packages": [
    "fd@latest",
    "fzf@latest",
    "gh@latest",
    "jq@latest",
    "ripgrep@latest",
    "tmux@latest",
    "vim@latest",
    "nodejs@lts"
  ]
}

~/sandcat-nodejs-lts-issue
❯ sudo ~/Software/sandcat/cli/bin/sandcat run --build

[blah...]

 => CACHED [stage-0  8/20] RUN mkdir -m 0755 /nix && chown vscode /nix                               0.0s
 => CACHED [stage-0  9/20] RUN curl -fsSL https://get.jetify.com/devbox | bash -s -- -f     && chmo  0.0s
 => CACHED [stage-0 10/20] RUN curl -fsSL -L https://nixos.org/nix/install     | sh -s -- --no-daem  0.0s
 => CACHED [stage-0 11/20] COPY --chown=vscode:vscode devbox.stack.json /home/vscode/.local/share/d  0.0s
 => ERROR [stage-0 12/20] RUN --mount=type=cache,target=/home/vscode/.cache/nix,uid=1000,gid=1000    2.6s
------                                                                                                    
 > [stage-0 12/20] RUN --mount=type=cache,target=/home/vscode/.cache/nix,uid=1000,gid=1000     . /home/vscode/.nix-profile/etc/profile.d/nix.sh  && devbox global install:                                          
✓ Downloading version 0.17.5... [DONE]
✓ Verifying checksum... [DONE]
✓ Unpacking binary... [DONE]
2.061 
2.103 Info: Ensuring packages are installed.
2.354 Error: nodejs@lts: package not found
2.354 
------
Dockerfile.app:72

--------------------

  71 |     COPY --chown=vscode:vscode devbox.stack.json /home/vscode/.local/share/devbox/global/default/devbox.json

  72 | >>> RUN --mount=type=cache,target=/home/vscode/.cache/nix,uid=1000,gid=1000 \

  73 | >>>     . /home/vscode/.nix-profile/etc/profile.d/nix.sh \

  74 | >>>  && devbox global install

  75 |     

--------------------

failed to solve: process "/bin/sh -c . /home/vscode/.nix-profile/etc/profile.d/nix.sh  && devbox global install" did not complete successfully: exit code: 1

[+] down 3/3
 ✔ Container wololo-wg-client-1 Removed                                                              12.4s
 ✔ Container wololo-mitmproxy-1 Removed                                                               0.5s
 ✔ Network wololo_default       Removed                                                               0.2s

~/sandcat-nodejs-lts-issue
❯ nvim .devcontainer/devbox.stack.json 

~/sandcat-nodejs-lts-issue
❯ cat .devcontainer/devbox.stack.json 
{
  "packages": [
    "fd@latest",
    "fzf@latest",
    "gh@latest",
    "jq@latest",
    "ripgrep@latest",
    "tmux@latest",
    "vim@latest",
    "nodejs"
  ]
}

~/sandcat-nodejs-lts-issue
❯ sudo ~/Software/sandcat/cli/bin/sandcat run --build

[blah...]

Image wololo-agent Built 
Container wololo-wg-client-1 Waiting 
Container wololo-wg-client-1 Healthy 
Container wololo-agent-run-0a87c67e9c68 Creating 
Container wololo-agent-run-0a87c67e9c68 Created 
Updating certificates in /etc/ssl/certs...
rehash: warning: skipping ca-certificates.crt, it does not contain exactly one certificate or CRL
1 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Loaded 0
0 env var(s) from /mitmproxy-config/sandcat.env
vscode ➜ /workspaces/wololo $ node --version
v24.18.1
```