### PR TITLE
Run the agent container with no_new_privs set

### DIFF
--- a/cli/templates/devcontainer/compose-all.yml
+++ b/cli/templates/devcontainer/compose-all.yml
@@ -6,6 +6,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.app
+    # We set `no-new-privileges` to true to "disable container processes from
+    # gaining new privileges."
+    # https://docs.docker.com/reference/cli/docker/container/run/#security-opt
+    # https://docs.docker.com/reference/compose-file/services/#security_opt
+    # https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt
+    security_opt:
+      - no-new-privileges
     # Share wg-client's network namespace so all traffic goes through its
     # WireGuard tunnel. The app container has no NET_ADMIN capability,
     # so processes inside cannot modify routing, iptables, or the tunnel.


### PR DESCRIPTION
I don't think it was intended for the agent to have root access in the container. Currently the agent can perform mischief such as writing a setuid binary in the project directory on the host.

The no_new_privs flag does not prevent app-init.sh from running as root. It does affect all setuid binaries, not just sudo.

Without this patch:
```bash
vscode ➜ /workspaces/t-sandbox $ sudo whoami
root
```

With this patch:
```bash
vscode ➜ /workspaces/t-sandbox $ sudo whoami
sudo: The "no new privileges" flag is set, which prevents sudo from running as root.
sudo: If sudo is running in a container, you may need to adjust the container configuration to disable the flag.
```

Interestingly, this setting also *enables* a new capability in the container: the ability to "install" (activate?) seccomp filters. I don't know if there is any use for this. The kernel documentation [2] says:

> Filters installed for the seccomp mode 2 sandbox persist across
   execve and can change the behavior of newly-executed programs.
   Unprivileged users are therefore only allowed to install such filters
   if no_new_privs is set.

References:
1. https://docs.docker.com/reference/cli/docker/container/run/#security-opt
2. https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt