### PR TITLE
Set uv TLS env vars automatically for the python stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1505,7 +1505,11 @@ enough for most tools — but some runtimes bring their own CA handling:
   trust store resolution. `app-user-init.sh` pre-creates the `scala-cli` config
   file with the trust store path so it works even before scala-cli is installed.
   Other native tools may need similar tool-specific configuration.
-- **Python** uses the system CA store — works out of the box.
+- **Python** uses the system CA store — works out of the box. The exception is
+  **uv**, which is itself a Rust binary and (like other `rustls`-based tools)
+  bundles its own root CAs. The `python` stack sets `UV_NATIVE_TLS` and
+  `UV_SYSTEM_CERTS` on the agent service automatically so `uv` reads the
+  system store instead.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1507,9 +1507,8 @@ enough for most tools — but some runtimes bring their own CA handling:
   Other native tools may need similar tool-specific configuration.
 - **Python** uses the system CA store — works out of the box. The exception is
   **uv**, which is itself a Rust binary and (like other `rustls`-based tools)
-  bundles its own root CAs. The `python` stack sets `UV_NATIVE_TLS` and
-  `UV_SYSTEM_CERTS` on the agent service automatically so `uv` reads the
-  system store instead.
+  bundles its own root CAs. The `python` stack sets `UV_SYSTEM_CERTS` on the
+  agent service automatically so `uv` reads the system store instead.
 
 ## Development
 

--- a/cli/lib/devcontainer.bash
+++ b/cli/lib/devcontainer.bash
@@ -175,6 +175,52 @@ apply_inline_placeholders() {
 	mv "$tmpfile" "$file"
 }
 
+# Adds stack-contributed environment variables (e.g. uv's TLS config for the
+# python stack) to services.agent.environment in compose-all.yml.
+# Args:
+#   $1 - Path to compose-all.yml
+#   $@ - Stack names (remaining args)
+customize_compose_stack_environment() {
+	local compose_file=$1
+	shift
+
+	local entries="" stack env
+	for stack in "$@"; do
+		env=$(stack_env_entries "$stack")
+		[[ -n "$env" ]] && entries="${entries}${env}"$'\n'
+	done
+
+	merge_compose_agent_environment "$compose_file" "$entries"
+}
+
+# Merges KEY=value environment entries into services.agent.environment in
+# compose-all.yml. Appends to any entries already present (rather than
+# overwriting) so agent- and stack-contributed variables coexist regardless
+# of call order. Building the array structurally avoids fragile
+# line-counting in compose-all.yml. No-op when passed no entries — compose
+# rejects `environment: {}`.
+# Args:
+#   $1 - Path to compose-all.yml
+#   $2 - Newline-separated "KEY=value" entries (empty lines ignored)
+merge_compose_agent_environment() {
+	local compose_file=$1
+	local entries=$2
+
+	local entry yq_array=""
+	while IFS= read -r entry; do
+		[[ -z "$entry" ]] && continue
+		# Wrap each entry as a JSON string for yq's expression parser;
+		# escape backslashes and double quotes so KEY=VALUE pairs with
+		# special characters round-trip correctly.
+		local escaped="${entry//\\/\\\\}"
+		escaped="${escaped//\"/\\\"}"
+		yq_array+="\"${escaped}\","
+	done <<< "$entries"
+	[[ -z "$yq_array" ]] && return 0
+	yq_array="[${yq_array%,}]"
+	yq -i ".services.agent.environment = ((.services.agent.environment // []) + ${yq_array})" "$compose_file"
+}
+
 # Replaces provider-specific placeholders in generated templates.
 # Args:
 #   $1 - Path to devcontainer directory
@@ -219,23 +265,7 @@ customize_agent_templates() {
 		"__AGENT_EXTENSION__" "$extension_replacement" \
 		"__AGENT_SETTINGS__"  "$settings_block"
 
-	# services.agent.environment is added via yq only when the agent
-	# contributes entries — compose rejects `environment: {}`. Building the
-	# array structurally avoids fragile line-counting in compose-all.yml.
-	if [[ -n "$environment_entries" ]]; then
-		local entry yq_array=""
-		while IFS= read -r entry; do
-			[[ -z "$entry" ]] && continue
-			# Wrap each entry as a JSON string for yq's expression parser;
-			# escape backslashes and double quotes so KEY=VALUE pairs with
-			# special characters round-trip correctly.
-			local escaped="${entry//\\/\\\\}"
-			escaped="${escaped//\"/\\\"}"
-			yq_array+="\"${escaped}\","
-		done <<< "$environment_entries"
-		yq_array="[${yq_array%,}]"
-		yq -i ".services.agent.environment = ${yq_array}" "$devcontainer_dir/compose-all.yml"
-	fi
+	merge_compose_agent_environment "$devcontainer_dir/compose-all.yml" "$environment_entries"
 
 	apply_template_placeholders \
 		"$devcontainer_dir/Dockerfile.app" \

--- a/cli/lib/stacks.bash
+++ b/cli/lib/stacks.bash
@@ -47,11 +47,13 @@ stack_extension() {
 # Returns newline-separated "KEY=value" environment entries a stack needs
 # set on the agent service (empty if none).
 #
-# python: uv (the default Python package manager) bundles its own root CA
-# store and doesn't consult the system trust store by default, so it fails
-# TLS verification against mitmproxy's intercepting CA. UV_SYSTEM_CERTS is
-# the current variable name; UV_NATIVE_TLS is the deprecated alias. Both are
-# set for compatibility across uv versions.
+# python: uv (a popular Python package manager) bundles its own root CA store
+# and doesn't consult the system trust store by default, so it fails TLS
+# verification against mitmproxy's intercepting CA. On Mar 23, 2026, uv 0.11.0
+# added UV_SYSTEM_CERTS to fix this. On May 5, 2026, uv 0.11.9 deprecated the
+# old UV_NATIVE_TLS variable that had served the same purpose. We set only the
+# new variable because the old variable causes uv to show a deprecation
+# message.
 stack_env_entries() {
 	case $1 in
 		python) echo "UV_SYSTEM_CERTS=1" ;;

--- a/cli/lib/stacks.bash
+++ b/cli/lib/stacks.bash
@@ -44,6 +44,20 @@ stack_extension() {
 	esac
 }
 
+# Returns newline-separated "KEY=value" environment entries a stack needs
+# set on the agent service (empty if none).
+#
+# python: uv (the default Python package manager) bundles its own root CA
+# store and doesn't consult the system trust store by default, so it fails
+# TLS verification against mitmproxy's intercepting CA. UV_SYSTEM_CERTS is
+# the current variable name; UV_NATIVE_TLS is the deprecated alias. Both are
+# set for compatibility across uv versions.
+stack_env_entries() {
+	case $1 in
+		python) printf '%s\n' "UV_NATIVE_TLS=1" "UV_SYSTEM_CERTS=1" ;;
+	esac
+}
+
 # Returns space-separated dependency stack names (empty if none).
 stack_deps() {
 	case $1 in

--- a/cli/lib/stacks.bash
+++ b/cli/lib/stacks.bash
@@ -54,7 +54,7 @@ stack_extension() {
 # set for compatibility across uv versions.
 stack_env_entries() {
 	case $1 in
-		python) printf '%s\n' "UV_NATIVE_TLS=1" "UV_SYSTEM_CERTS=1" ;;
+		python) echo "UV_SYSTEM_CERTS=1" ;;
 	esac
 }
 

--- a/cli/libexec/init/devcontainer
+++ b/cli/libexec/init/devcontainer
@@ -103,6 +103,7 @@ devcontainer() {
 		local stacks_arr=()
 		read -ra stacks_arr <<< "$stacks"
 		customize_devcontainer_extensions "$devcontainer_dir/devcontainer.json" "${stacks_arr[@]}"
+		customize_compose_stack_environment "$compose_file" "${stacks_arr[@]}"
 		customize_devbox "$devcontainer_dir" "${stacks_arr[@]}"
 	else
 		customize_devcontainer_extensions "$devcontainer_dir/devcontainer.json"

--- a/cli/test/init/extensions.bats
+++ b/cli/test/init/extensions.bats
@@ -212,3 +212,59 @@ teardown() {
 	run grep '__AGENT_MITM_STREAMING_FLAGS__' "$BATS_TEST_TMPDIR/sandcat/compose-proxy.yml"
 	assert_failure
 }
+
+# --------------------------------------------------- stack environment
+
+@test "customize_compose_stack_environment adds python's uv TLS env vars" {
+	echo 'services: {agent: {}}' > "$BATS_TEST_TMPDIR/compose-all.yml"
+
+	customize_compose_stack_environment "$BATS_TEST_TMPDIR/compose-all.yml" python
+
+	yq -e '.services.agent.environment[] | select(. == "UV_NATIVE_TLS=1")' \
+		"$BATS_TEST_TMPDIR/compose-all.yml"
+	yq -e '.services.agent.environment[] | select(. == "UV_SYSTEM_CERTS=1")' \
+		"$BATS_TEST_TMPDIR/compose-all.yml"
+}
+
+@test "customize_compose_stack_environment is a no-op for stacks without env contributions" {
+	echo 'services: {agent: {}}' > "$BATS_TEST_TMPDIR/compose-all.yml"
+
+	customize_compose_stack_environment "$BATS_TEST_TMPDIR/compose-all.yml" node java
+
+	# compose rejects `environment: {}` — the key must be entirely absent,
+	# not present-but-empty.
+	run yq -e '.services.agent | has("environment")' "$BATS_TEST_TMPDIR/compose-all.yml"
+	assert_failure
+}
+
+@test "customize_compose_stack_environment and customize_agent_templates environment entries coexist regardless of call order" {
+	# Real init flow calls the stack merge before the agent merge; this test
+	# guards against a regression where either merge overwrites the other's
+	# entries instead of appending (the bug the append-based
+	# merge_compose_agent_environment helper exists to prevent).
+	echo 'services: {agent: {}}' > "$BATS_TEST_TMPDIR/compose-all.yml"
+	echo "__AGENT_DOCKER_INSTALL__" > "$BATS_TEST_TMPDIR/Dockerfile.app"
+	echo "__AGENT_USER_INIT__" > "$BATS_TEST_TMPDIR/sandcat/scripts/app-user-init.sh"
+
+	customize_compose_stack_environment "$BATS_TEST_TMPDIR/compose-all.yml" python
+	customize_agent_templates "$BATS_TEST_TMPDIR" "claude"
+
+	yq -e '.services.agent.environment[] | select(. == "UV_NATIVE_TLS=1")' \
+		"$BATS_TEST_TMPDIR/compose-all.yml"
+	yq -e '.services.agent.environment[] | select(. == "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1")' \
+		"$BATS_TEST_TMPDIR/compose-all.yml"
+}
+
+@test "customize_agent_templates and customize_compose_stack_environment environment entries coexist in reverse call order" {
+	echo 'services: {agent: {}}' > "$BATS_TEST_TMPDIR/compose-all.yml"
+	echo "__AGENT_DOCKER_INSTALL__" > "$BATS_TEST_TMPDIR/Dockerfile.app"
+	echo "__AGENT_USER_INIT__" > "$BATS_TEST_TMPDIR/sandcat/scripts/app-user-init.sh"
+
+	customize_agent_templates "$BATS_TEST_TMPDIR" "claude"
+	customize_compose_stack_environment "$BATS_TEST_TMPDIR/compose-all.yml" python
+
+	yq -e '.services.agent.environment[] | select(. == "UV_NATIVE_TLS=1")' \
+		"$BATS_TEST_TMPDIR/compose-all.yml"
+	yq -e '.services.agent.environment[] | select(. == "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1")' \
+		"$BATS_TEST_TMPDIR/compose-all.yml"
+}

--- a/cli/test/init/extensions.bats
+++ b/cli/test/init/extensions.bats
@@ -220,8 +220,6 @@ teardown() {
 
 	customize_compose_stack_environment "$BATS_TEST_TMPDIR/compose-all.yml" python
 
-	yq -e '.services.agent.environment[] | select(. == "UV_NATIVE_TLS=1")' \
-		"$BATS_TEST_TMPDIR/compose-all.yml"
 	yq -e '.services.agent.environment[] | select(. == "UV_SYSTEM_CERTS=1")' \
 		"$BATS_TEST_TMPDIR/compose-all.yml"
 }
@@ -249,7 +247,7 @@ teardown() {
 	customize_compose_stack_environment "$BATS_TEST_TMPDIR/compose-all.yml" python
 	customize_agent_templates "$BATS_TEST_TMPDIR" "claude"
 
-	yq -e '.services.agent.environment[] | select(. == "UV_NATIVE_TLS=1")' \
+	yq -e '.services.agent.environment[] | select(. == "UV_SYSTEM_CERTS=1")' \
 		"$BATS_TEST_TMPDIR/compose-all.yml"
 	yq -e '.services.agent.environment[] | select(. == "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1")' \
 		"$BATS_TEST_TMPDIR/compose-all.yml"
@@ -263,7 +261,7 @@ teardown() {
 	customize_agent_templates "$BATS_TEST_TMPDIR" "claude"
 	customize_compose_stack_environment "$BATS_TEST_TMPDIR/compose-all.yml" python
 
-	yq -e '.services.agent.environment[] | select(. == "UV_NATIVE_TLS=1")' \
+	yq -e '.services.agent.environment[] | select(. == "UV_SYSTEM_CERTS=1")' \
 		"$BATS_TEST_TMPDIR/compose-all.yml"
 	yq -e '.services.agent.environment[] | select(. == "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1")' \
 		"$BATS_TEST_TMPDIR/compose-all.yml"

--- a/cli/test/init/stacks.bats
+++ b/cli/test/init/stacks.bats
@@ -85,6 +85,20 @@ teardown() {
 	assert_output ""
 }
 
+@test "stack_env_entries returns uv TLS config for python" {
+	run stack_env_entries python
+	assert_output "UV_NATIVE_TLS=1
+UV_SYSTEM_CERTS=1"
+}
+
+@test "stack_env_entries returns empty for stacks without env contributions" {
+	run stack_env_entries node
+	assert_output ""
+
+	run stack_env_entries java
+	assert_output ""
+}
+
 @test "stack_deps returns java for scala" {
 	run stack_deps scala
 	assert_output "java"

--- a/cli/test/init/stacks.bats
+++ b/cli/test/init/stacks.bats
@@ -87,8 +87,7 @@ teardown() {
 
 @test "stack_env_entries returns uv TLS config for python" {
 	run stack_env_entries python
-	assert_output "UV_NATIVE_TLS=1
-UV_SYSTEM_CERTS=1"
+	assert_output "UV_SYSTEM_CERTS=1"
 }
 
 @test "stack_env_entries returns empty for stacks without env contributions" {


### PR DESCRIPTION
## Message from human ~at 1am~

~**Sigh**. I fat fingered the PR button and opened this one before I meant to. This is AI slop until I review it and decide I can speak to it, at which point I will remove the draft status.~

This PR uses an env var to tell `uv` (a Python package manager) to use system TLS certificates.

## PR Message from Claude (edited):

uv bundles its own root CA store (it's a Rust binary using rustls) and doesn't consult the system trust store by default, so it fails TLS verification against mitmproxy's intercepting CA. Selecting the python stack now sets ~UV_NATIVE_TLS and~ UV_SYSTEM_CERTS on the agent service automatically.

Adds stack_env_entries() alongside the existing stack_extension() pattern, and customize_compose_stack_environment() to merge stack env vars into services.agent.environment. The existing per-agent environment merge (CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC etc.) was changed from an overwrite to an append so agent- and stack-contributed entries coexist regardless of call order.

Corrects the README's TLS/CA section, which claimed Python "works out of the box" without mentioning the situation with `uv`.