### PR TITLE
feat(cli): create empty .sandcat/settings.local.json scaffold on init

### DIFF
--- a/cli/libexec/init/settings
+++ b/cli/libexec/init/settings
@@ -25,7 +25,7 @@ settings() {
 		"$SCT_TEMPLATEDIR/settings.json" \
 		"$settings_file"
 
-	echo "Settings file created at $SCT_PROJECT_DIR/settings.json" | info
+	echo "Settings file created at $settings_file" | info
 
 	# Empty per-machine overrides scaffold — highest-precedence layer in the
 	# mitmproxy addon's settings merge. Sandcat's .gitignore keeps this file
@@ -35,7 +35,7 @@ settings() {
 	local local_settings="${settings_file%.json}.local.json"
 	if [[ ! -f "$local_settings" ]]; then
 		echo '{}' > "$local_settings"
-		echo "Local settings scaffold created at $SCT_PROJECT_DIR/settings.local.json" | info
+		echo "Local settings scaffold created at $local_settings" | info
 	fi
 }
 

--- a/cli/libexec/init/settings
+++ b/cli/libexec/init/settings
@@ -26,6 +26,17 @@ settings() {
 		"$settings_file"
 
 	echo "Settings file created at $SCT_PROJECT_DIR/settings.json" | info
+
+	# Empty per-machine overrides scaffold — highest-precedence layer in the
+	# mitmproxy addon's settings merge. Sandcat's .gitignore keeps this file
+	# local to the machine. Existence check preserves real credentials the
+	# user may have added; unlike the template settings.json above, this one
+	# is never overwritten on re-init.
+	local local_settings="${settings_file%.json}.local.json"
+	if [[ ! -f "$local_settings" ]]; then
+		echo '{}' > "$local_settings"
+		echo "Local settings scaffold created at $SCT_PROJECT_DIR/settings.local.json" | info
+	fi
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]

--- a/cli/test/init/settings.bats
+++ b/cli/test/init/settings.bats
@@ -30,3 +30,29 @@ teardown() {
 
 	[[ -f "$settings_file" ]]
 }
+
+@test "settings creates empty settings.local.json scaffold when absent" {
+	local settings_file="$BATS_TEST_TMPDIR/settings.json"
+	local local_settings="$BATS_TEST_TMPDIR/settings.local.json"
+
+	run settings "$settings_file" "github"
+	assert_success
+
+	[[ -f "$local_settings" ]]
+	run cat "$local_settings"
+	assert_output "{}"
+}
+
+@test "settings preserves an existing settings.local.json" {
+	local settings_file="$BATS_TEST_TMPDIR/settings.json"
+	local local_settings="$BATS_TEST_TMPDIR/settings.local.json"
+
+	# Simulate a user who already put real credentials in the local file.
+	printf '{"secrets":{"MY_TOKEN":{"value":"real"}}}' > "$local_settings"
+
+	run settings "$settings_file" "github"
+	assert_success
+
+	run cat "$local_settings"
+	assert_output --partial '"real"'
+}


### PR DESCRIPTION
Fixes #27.

## Summary

The mitmproxy addon has always read a third settings layer at `.sandcat/settings.local.json` for per-machine overrides (highest precedence, above the team-shared `settings.json`), and sandcat's `.gitignore` template already keeps it out of git — but the file itself was never scaffolded. Users had to know the convention exists.

Create an empty `{}` file on `sandcat init` when it doesn't already exist, so the layer is visible in the project tree right next to `settings.json`. Existence check preserves any real credentials the user may have added on a re-init; unlike `settings.json` (which is regenerated from template), `settings.local.json` is never overwritten.

Closes the third sub-request of #27. The other two ("create global settings with credentials" + "add local settings to .gitignore automatically") were already implemented earlier — see the issue body for the full trio.

## Test plan

- [x] `cli/test/init/settings.bats` — 4/4 pass, including two new tests:
  - `settings creates empty settings.local.json scaffold when absent`
  - `settings preserves an existing settings.local.json`
- [x] Full init bats suite still green (133/133)

🤖 Generated with [Claude Code](https://claude.com/claude-code)