### PR TITLE
security(image): remove vscode passwordless-sudo grant

### DIFF
--- a/cli/templates/devcontainer/Dockerfile.app
+++ b/cli/templates/devcontainer/Dockerfile.app
@@ -18,6 +18,15 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends gosu jq rsync \
     && rm -rf /var/lib/apt/lists/*
 
+# The devcontainers base image grants vscode passwordless sudo
+# (/etc/sudoers.d/vscode: `vscode ALL=(root) NOPASSWD:ALL`). Sandcat's
+# design gives the agent no legitimate sudo use — every root-phase step
+# runs in the entrypoint (app-init.sh) before it drops to vscode via gosu.
+# Remove the grant so the image is hardened even when run outside sandcat's
+# compose; inside compose this is the image-level layer of the same defense
+# whose runtime layer is `security_opt: no-new-privileges` (issue #12, #90).
+RUN rm -f /etc/sudoers.d/vscode
+
 COPY --chmod=755 sandcat/scripts/app-init.sh /usr/local/bin/app-init.sh
 COPY --chmod=755 sandcat/scripts/app-user-init.sh /usr/local/bin/app-user-init.sh
 COPY --chown=vscode:vscode sandcat/tmux.conf /home/vscode/.tmux.conf

--- a/cli/test/init/regression.bats
+++ b/cli/test/init/regression.bats
@@ -351,6 +351,12 @@ cursor_agent_compose_file_has_expected_content() {
 
 	assert_devcontainer_volume "$effective_file"
 	assert_jetbrains_capabilities "$effective_file"
+
+	# The generated Dockerfile.app removes the base image's passwordless-sudo
+	# grant for vscode, so the image is hardened even when run outside
+	# sandcat's compose (issue #12).
+	run grep -F 'rm -f /etc/sudoers.d/vscode' "$PROJECT_DIR/.devcontainer/Dockerfile.app"
+	assert_success
 }
 
 @test "devcontainer end-to-end: creates devcontainer config for cursor agent" {


### PR DESCRIPTION
Closes #12.

## Summary

The devcontainers base image ships `/etc/sudoers.d/vscode` (`vscode ALL=(root) NOPASSWD:ALL`). Sandcat's agent has no legitimate sudo use — every root-phase step runs in the entrypoint (`app-init.sh`) before it drops to the vscode user via `gosu` — so the grant is pure attack surface. This removes it at build time (`RUN rm -f /etc/sudoers.d/vscode` in `Dockerfile.app`).

## Two-layer defense

Issue #12 had two parts: (1) sandcat's setup must not *require* sudo — already true (grep of `cli/**` finds zero sudo usage; the only `sudo` in the repo is the host-side Docker install instruction in the README), and (2) the user must not be *able* to sudo inside the image.

Part 2 was partly addressed by #90's runtime `security_opt: no-new-privileges`, but that's a compose-level knob — the image run bare (`docker run -u vscode <agent-image>`) still had the grant. This PR closes that gap at the image level:

- **Inside sandcat compose**: sudo blocked by two independent layers (removed grant + no-new-privileges).
- **Bare image, outside compose**: the removed grant alone denies it.

## Test plan

- [x] `regression.bats` e2e (real `sandcat init` → generated project): asserts `Dockerfile.app` contains `rm -f /etc/sudoers.d/vscode`. Full `test/init/` suite green (131 tests).
- [x] Hands-on, real containers:
  - Base image control: `docker run -u vscode mcr.microsoft.com/devcontainers/base:debian bash -c 'sudo -n whoami'` → `root` (exit 0) — the vulnerability the issue reports.
  - Sandcat agent image, entrypoint bypassed: `sudo -n whoami` → `sudo: a password is required` (exit 1); `/etc/sudoers.d/vscode` absent; `sudo` binary still present (no grant = harmless).
  - In-sandbox: `sudo -n whoami` → blocked by the no-new-privileges message; `NoNewPrivs: 1`.

## Notes

- The `sudo` binary is deliberately left installed — removing only the grant means it prompts for a root password that doesn't exist, which is the standard hardened posture. No devcontainer Feature or sandcat runtime step depends on runtime sudo (build-time root work uses `USER root` in the Dockerfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFCiFbv1Cpr7yzCU8ftvzZ