### PR TITLE
docs: sidebar — Getting started group with visible Quick start steps

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,14 @@ pygments_style = "default"
 # -- Options for HTML output ----------------------------------------------
 
 html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    # Keep the sidebar tree expanded so the Quick start steps (and every
+    # group's pages) are visible without clicking into a page first.
+    "collapse_navigation": False,
+    # Sidebar shows groups → pages → page sections; deeper heading levels
+    # (####) stay out of the tree.
+    "navigation_depth": 3,
+}
 htmlhelp_basename = "sandcatdoc"
 
 highlight_language = "bash"

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ VirtusLab's AI-native SDLC platform.
 ```{eval-rst}
 .. toctree::
    :maxdepth: 2
+   :caption: Getting started
 
    getting-started/quickstart
 


### PR DESCRIPTION
Follow-up to #114/#115 (no separate issue — sidebar-only fixes). Two changes: (1) `collapse_navigation: False` + `navigation_depth: 3` keep the whole tree expanded, so the Quick start steps and every group's pages/sections are visible without clicking (79 sidebar items, level-3 adds only 4); (2) the Quick start page sits under a proper **Getting started** caption, level with Agents/IDE integration/Installation — previously it rendered as a bare link above the groups. Verified with strict local builds and preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)